### PR TITLE
feat: Playlist Menu 

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'example'
+rootProject.name = 'azusa-player-mobile'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
 includeBuild('../node_modules/react-native-gradle-plugin')

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -22,7 +22,7 @@ if linkage != nil
   use_frameworks! :linkage => linkage.to_sym
 end
 
-target 'example' do
+target 'azusa-player-mobile' do
   config = use_native_modules!
 
   # Flags change depending on the env values.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-native-reanimated": "^3.1.0",
     "react-native-safe-area-context": "^4.5.2",
     "react-native-screens": "^3.20.0",
+    "react-native-snackbar": "^2.4.0",
     "react-native-tab-view": "^3.5.1",
     "react-native-vector-icons": "^9.2.0",
     "react-native-windows": "^0.65.0-0",

--- a/src/components/buttons/PlaylistMenuButton.tsx
+++ b/src/components/buttons/PlaylistMenuButton.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { IconButton } from 'react-native-paper';
+import Dialog from '../playlist/PlaylistMenu';
+import coordinates from '../../objects/Coordinate';
+import { GestureResponderEvent } from 'react-native';
+
+const ICON = 'dots-horizontal';
+
+export default () => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [menuCoords, setMenuCoords] = useState<coordinates>({ x: 0, y: 0 });
+
+  const handlePress = (event: GestureResponderEvent) => {
+    setDialogOpen(true);
+    setMenuCoords({
+      x: event.nativeEvent.pageX,
+      y: event.nativeEvent.pageY,
+    });
+  };
+
+  const toggleVisible = () => {
+    setDialogOpen(val => !val);
+  };
+
+  return (
+    <React.Fragment>
+      <IconButton icon={ICON} onPress={handlePress} size={25} />
+      <Dialog
+        visible={dialogOpen}
+        toggleVisible={toggleVisible}
+        menuCoords={menuCoords}
+      />
+    </React.Fragment>
+  );
+};

--- a/src/components/buttons/PlaylistSettingsButton.tsx
+++ b/src/components/buttons/PlaylistSettingsButton.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { IconButton, Menu } from 'react-native-paper';
+import Dialog from '../dialogs/PlaylistSettingsDialog';
+import Playlist from '../../objects/Playlist';
+
+const ICON = 'pencil';
+
+interface menuProps {
+  disabled?: boolean;
+  onSubmit?: (playlist: Playlist) => void;
+  onCancel?: () => void;
+}
+
+export default ({
+  disabled = false,
+  onSubmit = (playlist: Playlist) => void 0,
+  onCancel = () => void 0,
+}: menuProps) => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const handleClose = () => {
+    setDialogOpen(false);
+    onCancel();
+  };
+
+  const handleSubmit = (playlist: Playlist) => {
+    setDialogOpen(false);
+    onSubmit(playlist);
+  };
+
+  return (
+    <React.Fragment>
+      <Menu.Item
+        leadingIcon={ICON}
+        onPress={() => {
+          setDialogOpen(true);
+        }}
+        title="Settings..."
+        disabled={disabled}
+      />
+      <Dialog
+        visible={dialogOpen}
+        onClose={handleClose}
+        onSubmit={handleSubmit}
+      />
+    </React.Fragment>
+  );
+};

--- a/src/components/dialogs/CopiedPlaylistDialog.tsx
+++ b/src/components/dialogs/CopiedPlaylistDialog.tsx
@@ -53,7 +53,7 @@ export default ({
       <Dialog
         visible={visible}
         onDismiss={handleClose}
-        style={{ height: '70%' }}
+        style={{ maxHeight: '70%' }}
       >
         <Dialog.Title>{`Send ${fromList.title} to...`}</Dialog.Title>
         <Dialog.Content style={{ ...styles.topBarContainer, height: '70%' }}>

--- a/src/components/dialogs/PlaylistSettingsDialog.tsx
+++ b/src/components/dialogs/PlaylistSettingsDialog.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, View } from 'react-native';
+import {
+  Button,
+  Dialog,
+  Portal,
+  Provider,
+  Text,
+  TextInput,
+  Switch,
+} from 'react-native-paper';
+import Playlist from '../../objects/Playlist';
+import { useNoxSetting } from '../../hooks/useSetting';
+
+interface props {
+  visible: boolean;
+  onClose?: () => void;
+  onSubmit?: (newPlaylist: Playlist) => void;
+}
+
+export default ({
+  visible,
+  onClose = () => void 0,
+  onSubmit = () => void 0,
+}: props) => {
+  const currentPlaylist = useNoxSetting(state => state.currentPlaylist);
+  const updatePlaylist = useNoxSetting(state => state.updatePlaylist);
+  const [playlistName, setPlaylistName] = useState(currentPlaylist.title);
+  const [subscribeUrl, setSubscribeUrl] = useState('');
+  const [blacklistedUrl, setBlacklistedUrl] = useState('');
+  const [useBiliShazam, setUseBiliShazam] = useState(false);
+
+  React.useEffect(() => {
+    setPlaylistName(currentPlaylist.title);
+    setSubscribeUrl(currentPlaylist.subscribeUrl.join(';'));
+    setBlacklistedUrl(currentPlaylist.blacklistedUrl.join(';'));
+    setUseBiliShazam(currentPlaylist.useBiliShazam);
+  }, [currentPlaylist]);
+
+  const toggleBiliShazam = () => setUseBiliShazam(val => !val);
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleSubmit = () => {
+    const newPlaylist: Playlist = {
+      ...currentPlaylist,
+      title: playlistName,
+      subscribeUrl: Array.from(new Set(subscribeUrl.split(';'))),
+      blacklistedUrl: Array.from(new Set(blacklistedUrl.split(';'))),
+      useBiliShazam: useBiliShazam,
+    };
+    updatePlaylist(newPlaylist, [], []);
+    onSubmit(newPlaylist);
+  };
+
+  return (
+    <Portal>
+      <Dialog visible={visible} onDismiss={handleClose}>
+        <KeyboardAvoidingView style={{ minHeight: '10%' }}>
+          <Dialog.Content>
+            <TextInput
+              label="Playlist Name"
+              value={playlistName}
+              onChangeText={(val: string) => setPlaylistName(val)}
+            />
+            <TextInput
+              label="Subscribe URL"
+              value={subscribeUrl}
+              onChangeText={(val: string) => setSubscribeUrl(val)}
+            />
+            <TextInput
+              label="Playlist Name"
+              value={blacklistedUrl}
+              onChangeText={(val: string) => setBlacklistedUrl(val)}
+            />
+            <View style={{ flexDirection: 'row' }}>
+              <Switch value={useBiliShazam} onValueChange={toggleBiliShazam} />
+              <Text style={{ fontSize: 18 }}>{'Use BiliShazam'}</Text>
+            </View>
+          </Dialog.Content>
+        </KeyboardAvoidingView>
+
+        <Dialog.Actions>
+          <Button onPress={handleClose}>Cancel</Button>
+          <Button onPress={handleSubmit}>Done</Button>
+        </Dialog.Actions>
+      </Dialog>
+    </Portal>
+  );
+};

--- a/src/components/playlist/BiliSearchbar.tsx
+++ b/src/components/playlist/BiliSearchbar.tsx
@@ -9,16 +9,19 @@ export default ({
   onSearched = (songs: Array<Song>) => console.log(songs),
 }) => {
   const [searchVal, setSearchVal] = useState('');
-  const [searchProgress, setSearchProgress] = useState(0);
+  const searchProgress = useNoxSetting(state => state.searchBarProgress);
+  const progressEmitter = useNoxSetting(
+    state => state.searchBarProgressEmitter
+  );
   const searchPlaylist = useNoxSetting(state => state.searchPlaylist);
   const setSearchPlaylist = useNoxSetting(state => state.setSearchPlaylist);
   const setCurrentPlaylist = useNoxSetting(state => state.setCurrentPlaylist);
 
   const handleSearch = async (val = searchVal) => {
-    setSearchProgress(1);
+    progressEmitter(100);
     const searchedResult = (await searchBiliURLs({
       input: val,
-      progressEmitter: (val: number) => setSearchProgress(val / 100),
+      progressEmitter,
       favList: [],
       useBiliTag: false,
     })) as Array<Song>;

--- a/src/components/playlist/PlaylistList.tsx
+++ b/src/components/playlist/PlaylistList.tsx
@@ -6,10 +6,10 @@ import { IconButton, Text } from 'react-native-paper';
 import { Dimensions } from 'react-native';
 import SongInfo from './SongInfo';
 import { useNoxSetting } from '../../hooks/useSetting';
-import { seconds2HHMMSS } from '../../utils/Utils';
 import SongMenu from './SongMenu';
 import Song from '../../objects/SongInterface';
 import PlaylistInfo from './PlaylistInfo';
+import PlaylistMenuButton from '../buttons/PlaylistMenuButton';
 
 /*
 import Song, { dummySong } from '../../objects/SongInterface';
@@ -84,7 +84,7 @@ export default () => {
   };
 
   // TODO: useDebunce here
-  const handleSearch = (searchedVal: string) => {
+  const handleSearch = (searchedVal = '') => {
     if (searchedVal === '') {
       setCurrentRows(currentPlaylist.songList);
       return;
@@ -92,12 +92,17 @@ export default () => {
     setCurrentRows(reParseSearch(searchedVal, currentPlaylist.songList));
   };
 
+  /**
+   * playlistShouldReRender is a global state that indicates playlist should be
+   * refreshed. right now its only called when the playlist is updated in updatePlaylist.
+   * this should in turn clear all searching, checking and filtering.
+   */
   useEffect(() => {
     resetSelected();
     setChecking(false);
     setSearching(false);
     setCurrentRows(currentPlaylist.songList);
-  }, [currentPlaylist]);
+  }, [currentPlaylist, playlistShouldReRender]);
 
   useEffect(() => {
     setShouldReRender(val => !val);
@@ -133,11 +138,7 @@ export default () => {
             size={25}
             mode={searching ? 'contained' : undefined}
           />
-          <IconButton
-            icon="dots-horizontal"
-            onPress={() => console.log}
-            size={25}
-          />
+          <PlaylistMenuButton />
         </View>
       </View>
       <View

--- a/src/components/playlist/PlaylistMenu.tsx
+++ b/src/components/playlist/PlaylistMenu.tsx
@@ -1,39 +1,220 @@
 import * as React from 'react';
-import {
-    Menu,
-  } from 'react-native-paper';
+import { Menu } from 'react-native-paper';
+import { Alert } from 'react-native';
+import Snackbar from 'react-native-snackbar';
 import { useNoxSetting } from '../../hooks/useSetting';
+import coordinates from '../../objects/Coordinate';
+import playlistAnalytics from '../../utils/Analytics';
+import PlaylistSettingsButton from '../buttons/PlaylistSettingsButton';
+import { PLAYLIST_ENUMS } from '../../enums/Playlist';
+import { CopiedPlaylistMenuItem } from '../buttons/CopiedPlaylistButton';
+import { twoWayAlert } from '../../utils/Utils';
+import { getBVIDList, biliShazamOnSonglist } from '../../utils/DataProcess';
+import { getPlaylistUniqBVIDs } from '../../objects/Playlist';
+import { fetchVideoInfo } from '../../utils/Data';
 
 enum ICONS {
-  SETTINGS = '',
-  BILISHAZAM = '',
-  REMOVE_BILISHAZAM = '',
-  ANALYTICS = '',
-  REMOVE_BROKEN = '',
-  RELOAD_BVIDS = '',
-  CLEAR = '',
-  REMOVE = '',
+  SETTINGS = 'cog',
+  BILISHAZAM = 'magnify-plus',
+  REMOVE_BILISHAZAM = 'magnify-close',
+  ANALYTICS = 'google-analytics',
+  REMOVE_BROKEN = 'link-variant-remove',
+  RELOAD_BVIDS = 'reload',
+  CLEAR = 'notification-clear-all',
+  REMOVE = 'trash-can',
 }
 
-export default (visible: boolean, setVisible: (val: boolean) => void, selected: boolean[] = []) => {
+interface props {
+  visible?: boolean;
+  toggleVisible?: () => void;
+  menuCoords?: coordinates;
+}
+
+export default ({
+  visible = false,
+  toggleVisible = () => void 0,
+  menuCoords = { x: 0, y: 0 },
+}: props) => {
+  const [SnackbarVisible, setSnackbarVisible] = React.useState(false);
 
   const currentPlaylist = useNoxSetting(state => state.currentPlaylist);
-  const menuCoord = useNoxSetting(state => state.playlistMenuCoords);
+  const updatePlaylist = useNoxSetting(state => state.updatePlaylist);
+  const removePlaylist = useNoxSetting(state => state.removePlaylist);
+  const progressEmitter = useNoxSetting(
+    state => state.searchBarProgressEmitter
+  );
+  const limitedPlaylistFeatures =
+    currentPlaylist.type !== PLAYLIST_ENUMS.TYPE_TYPICA_PLAYLIST;
+
+  // TODO: useCallback?
+  const playlistAnalysis = (playlist = currentPlaylist) => {
+    const analytics = playlistAnalytics(playlist);
+    Alert.alert(
+      `歌单 ${playlist.title} 的统计信息`,
+      [
+        `歌单内总共有${analytics.songsUnique.size}首独特的歌`,
+        `歌单内最常出现的歌：${analytics.songTop10
+          .slice(-5)
+          .map(val => `${val[0]} (${String(val[1])})`)
+          .join(', ')}`,
+        `最近的新歌：${Array.from(analytics.songsUnique)
+          .slice(-5)
+          .reverse()
+          .join(', ')}`,
+        `bv号总共有${String(analytics.bvid.size)}个，平均每bv号有${(
+          analytics.totalCount / analytics.bvid.size
+        ).toFixed(1)}首歌`,
+        `shazam失败的歌数: ${String(analytics.invalidShazamCount)}/${String(
+          analytics.totalCount
+        )} (${(
+          (analytics.invalidShazamCount * 100) /
+          analytics.totalCount
+        ).toFixed(1)}%)`,
+      ].join('\n'),
+      [{ text: 'OK', onPress: toggleVisible }],
+      { cancelable: true, onDismiss: toggleVisible }
+    );
+  };
+
+  const confirmOnPlaylistClear = (playlist = currentPlaylist) => {
+    twoWayAlert(
+      `Claer ${playlist.title}?`,
+      `Are you sure to clear playlist ${playlist.title}?`,
+      () => {
+        updatePlaylist(
+          {
+            ...playlist,
+            songList: [],
+          },
+          [],
+          []
+        );
+        toggleVisible();
+      }
+    );
+  };
+
+  const confirmOnPlaylistDelete = (playlist = currentPlaylist) => {
+    twoWayAlert(
+      `Delete ${playlist.title}?`,
+      `Are you sure to delete playlist ${playlist.title}?`,
+      () => {
+        removePlaylist(playlist.id);
+        toggleVisible();
+      }
+    );
+  };
+
+  const confirmOnPlaylistReload = (playlist = currentPlaylist) => {
+    twoWayAlert(
+      `Reload ${playlist.title}?`,
+      `Are you sure to reload all BVIDs in playlist ${playlist.title}?`,
+      async () => {
+        Snackbar.show({
+          text: '正在重载歌单……',
+          duration: Snackbar.LENGTH_INDEFINITE,
+        });
+        const newSongList = await getBVIDList({
+          bvids: getPlaylistUniqBVIDs(playlist),
+          progressEmitter,
+          useBiliTag: playlist.useBiliShazam,
+        });
+        updatePlaylist(
+          {
+            ...playlist,
+            songList: newSongList!,
+          },
+          [],
+          []
+        );
+        Snackbar.dismiss();
+        Snackbar.show({ text: '重载歌单完成' });
+        toggleVisible();
+      }
+    );
+  };
+
+  const playlistCleanup = async (playlist = currentPlaylist) => {
+    const promises: Promise<any>[] = [];
+    const validBVIds: Array<string> = [];
+    Snackbar.show({
+      text: '正在清理歌单无效的BV号……',
+      duration: Snackbar.LENGTH_INDEFINITE,
+    });
+    progressEmitter(100);
+    getPlaylistUniqBVIDs(playlist).forEach(bvid =>
+      promises.push(
+        fetchVideoInfo(bvid).then(val => validBVIds.push(val?.bvid))
+      )
+    );
+    await Promise.all(promises);
+    progressEmitter(0);
+    Snackbar.dismiss();
+    Snackbar.show({ text: '歌单清理完成' });
+    console.log(validBVIds);
+  };
+
+  const playlistBiliShazam = async (playlist = currentPlaylist) => {
+    progressEmitter(100);
+    Snackbar.show({
+      text: `正在用b站识歌 on ${playlist.title}……`,
+      duration: Snackbar.LENGTH_INDEFINITE,
+    });
+    const newSongList = await biliShazamOnSonglist(playlist.songList, false);
+    updatePlaylist(
+      {
+        ...playlist,
+        songList: newSongList,
+      },
+      [],
+      []
+    );
+    Snackbar.dismiss();
+    Snackbar.show({ text: '歌单识歌完成' });
+    progressEmitter(0);
+  };
 
   return (
-      <Menu
-          visible={visible}
-          onDismiss={() => setVisible(false)}
-          anchor={menuCoord}
-        >
-          <Menu.Item leadingIcon={ICONS.SETTINGS} onPress={() => {}} title="Settings" />
-          <Menu.Item leadingIcon={ICONS.BILISHAZAM} onPress={() => {}} title="BiliShazam" />
-          <Menu.Item leadingIcon={ICONS.REMOVE_BILISHAZAM} onPress={() => {}} title="Remove BiliShazam" />
-          <Menu.Item leadingIcon={ICONS.ANALYTICS} onPress={() => {}} title="Analytics" />
-          <Menu.Item leadingIcon={ICONS.REMOVE_BROKEN} onPress={() => {}} title="Remove Broken" />
-          <Menu.Item leadingIcon={ICONS.RELOAD_BVIDS} onPress={() => {}} title="Reload Bvids" />
-          <Menu.Item leadingIcon={ICONS.CLEAR} onPress={() => {}} title="Clear" />
-          <Menu.Item leadingIcon={ICONS.REMOVE} onPress={() => {}} title="Remove" />
-        </Menu>
-  )
-}
+    <Menu visible={visible} onDismiss={toggleVisible} anchor={menuCoords}>
+      <PlaylistSettingsButton disabled={limitedPlaylistFeatures} />
+      <CopiedPlaylistMenuItem
+        getFromListOnClick={() => currentPlaylist}
+        onSubmit={() => toggleVisible()}
+      />
+      <Menu.Item
+        leadingIcon={ICONS.BILISHAZAM}
+        onPress={() => playlistBiliShazam()}
+        title="BiliShazam"
+      />
+      <Menu.Item
+        leadingIcon={ICONS.ANALYTICS}
+        onPress={() => playlistAnalysis()}
+        title="Analytics"
+      />
+      <Menu.Item
+        leadingIcon={ICONS.REMOVE_BROKEN}
+        onPress={() => playlistCleanup()}
+        title="Remove Broken"
+        disabled={limitedPlaylistFeatures}
+      />
+      <Menu.Item
+        leadingIcon={ICONS.RELOAD_BVIDS}
+        onPress={() => confirmOnPlaylistReload()}
+        title="Reload Bvids"
+        disabled={limitedPlaylistFeatures}
+      />
+      <Menu.Item
+        leadingIcon={ICONS.CLEAR}
+        onPress={() => confirmOnPlaylistClear()}
+        title="Clear"
+        disabled={limitedPlaylistFeatures}
+      />
+      <Menu.Item
+        leadingIcon={ICONS.REMOVE}
+        onPress={() => confirmOnPlaylistDelete()}
+        title="Remove"
+        disabled={limitedPlaylistFeatures}
+      />
+    </Menu>
+  );
+};

--- a/src/components/playlist/SongMenu.tsx
+++ b/src/components/playlist/SongMenu.tsx
@@ -3,6 +3,7 @@ import { Menu } from 'react-native-paper';
 import { useNoxSetting } from '../../hooks/useSetting';
 import { CopiedPlaylistMenuItem } from '../buttons/CopiedPlaylistButton';
 import { RenameSongMenuItem } from '../buttons/RenameSongButton';
+import Playlist from '../../objects/Playlist';
 
 enum ICONS {
   SEND_TO = 'playlist-plus',
@@ -66,10 +67,16 @@ export default ({
   };
 
   const renameSong = (rename: string) => {
-    // i sure hope this doesnt break anything...
-    const song = currentPlaylist.songList[songMenuSongIndexes[0]];
-    song.name = song.parsedName = rename;
-    updatePlaylist(currentPlaylist, [], []);
+    const newPlaylist = {
+      ...currentPlaylist,
+      songList: Array.from(currentPlaylist.songList),
+    };
+    newPlaylist.songList[songMenuSongIndexes[0]] = {
+      ...newPlaylist.songList[songMenuSongIndexes[0]],
+      name: rename,
+      parsedName: rename,
+    };
+    updatePlaylist(newPlaylist, [], []);
   };
 
   return (

--- a/src/components/playlists/View.tsx
+++ b/src/components/playlists/View.tsx
@@ -14,6 +14,7 @@ import { ViewEnum } from '../../enums/View';
 import AddPlaylistButton from '../buttons/AddPlaylistButton';
 import { STORAGE_KEYS } from '../../utils/ChromeStorage';
 import NewPlaylistDialog from '../dialogs/NewPlaylistDialog';
+import { twoWayAlert } from '../../utils/Utils';
 
 export default (props: any) => {
   const navigation = useNavigation();
@@ -34,17 +35,10 @@ export default (props: any) => {
   };
 
   const confirmOnDelete = (playlistId: string) => {
-    Alert.alert(
+    twoWayAlert(
       `Delete ${playlists[playlistId].title}?`,
       `Are you sure to delete playlist ${playlists[playlistId].title}?`,
-      [
-        {
-          text: 'Cancel',
-          onPress: () => void 0,
-          style: 'cancel',
-        },
-        { text: 'OK', onPress: () => removePlaylist(playlistId) },
-      ]
+      () => removePlaylist(playlistId)
     );
   };
 

--- a/src/enums/Playlist.ts
+++ b/src/enums/Playlist.ts
@@ -1,0 +1,5 @@
+export enum PLAYLIST_ENUMS {
+  TYPE_TYPICA_PLAYLIST = 'typical',
+  TYPE_SEARCH_PLAYLIST = 'search',
+  TYPE_FAVORI_PLAYLIST = 'favorite',
+}

--- a/src/hooks/useSetting.ts
+++ b/src/hooks/useSetting.ts
@@ -17,6 +17,9 @@ import Song from '../objects/SongInterface';
 import coordinates from '../objects/Coordinate';
 
 interface NoxSetting {
+  searchBarProgress: number;
+  searchBarProgressEmitter: (val: number) => undefined;
+
   songMenuCoords: coordinates;
   setSongMenuCoords: (val: coordinates) => void;
   songMenuVisible: boolean;
@@ -72,6 +75,11 @@ interface NoxSetting {
  * as well as saving and loading states to/from asyncStorage.
  */
 export const useNoxSetting = create<NoxSetting>((set, get) => ({
+  searchBarProgress: 0,
+  searchBarProgressEmitter: (val: number) => {
+    set({ searchBarProgress: val / 100 });
+    return void 0;
+  },
   songMenuCoords: { x: 0, y: 0 },
   setSongMenuCoords: (val: coordinates) => set({ songMenuCoords: val }),
   songMenuVisible: false,
@@ -162,9 +170,10 @@ export const useNoxSetting = create<NoxSetting>((set, get) => ({
     set({
       currentPlaylist: notNullDefault(
         val.playlists[val.lastPlaylistId[0]],
-        dummyPlaylist()
+        val.searchPlaylist
       ),
     });
+    set({ searchPlaylist: val.searchPlaylist });
     set({ favoritePlaylist: val.favoriPlaylist });
     set({ playerSetting: val.settings ? val.settings : DEFAULT_SETTING });
     set({ playerRepeat: val.playerRepeat });

--- a/src/objects/Playlist.ts
+++ b/src/objects/Playlist.ts
@@ -1,13 +1,8 @@
 import { Track } from 'react-native-track-player';
 import { v4 as uuidv4 } from 'uuid';
 import Song from './SongInterface';
-import { resolveUrl, NULL_TRACK } from './SongOperations';
-
-export enum PLAYLIST_ENUMS {
-  TYPE_TYPICA_PLAYLIST = 'typical',
-  TYPE_SEARCH_PLAYLIST = 'search',
-  TYPE_FAVORI_PLAYLIST = 'favorite',
-}
+import { NULL_TRACK } from './SongOperations';
+import { PLAYLIST_ENUMS } from '../enums/Playlist';
 
 export default interface Playlist {
   songList: Array<Song>;
@@ -37,6 +32,15 @@ export const dummyPlaylist = (
 };
 
 export const dummyPlaylistList = dummyPlaylist();
+
+export const getPlaylistUniqBVIDs = (playlist: Playlist) => {
+  return Array.from(
+    playlist.songList.reduce(
+      (accumulator, currentValue) => accumulator.add(currentValue.bvid),
+      new Set() as Set<string>
+    )
+  );
+};
 
 export const playlistToTracklist = (
   playlist: Playlist,

--- a/src/objects/SongOperations.ts
+++ b/src/objects/SongOperations.ts
@@ -51,13 +51,19 @@ export default ({
   };
 };
 
-export const setSongBiliShazamed = (song: SongInterface, val: string) => {
-  song.biliShazamedName = val;
-  if (!val) return;
-  song.biliShazamedName = extractParenthesis(val);
-  song.nameRaw = song.name;
-  song.name = song.biliShazamedName;
-  song.parsedName = song.biliShazamedName;
+export const setSongBiliShazamed = (
+  song: SongInterface,
+  val: string | null
+) => {
+  if (!val) return { ...song, biliShazamedName: val } as SongInterface;
+  const biliShazamedName = extractParenthesis(val);
+  return {
+    ...song,
+    biliShazamedName,
+    nameRaw: song.name,
+    name: biliShazamedName,
+    parsedName: biliShazamedName,
+  } as SongInterface;
 };
 
 export const removeSongBiliShazamed = (song: SongInterface) => {

--- a/src/utils/ChromeStorage.ts
+++ b/src/utils/ChromeStorage.ts
@@ -1,13 +1,14 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { strToU8, strFromU8, compressSync, decompressSync } from 'fflate';
-import Playlist, { dummyPlaylist, PLAYLIST_ENUMS } from '../objects/Playlist';
+import Playlist, { dummyPlaylist } from '../objects/Playlist';
 import { notNullDefault } from './Utils';
 import { NoxRepeatMode } from '../components/player/enums/repeatMode';
 import Song from '../objects/SongInterface';
+import { PLAYLIST_ENUMS } from '../enums/Playlist';
 /**
  * noxplayer's storage handler.
  * ChromeStorage has quite a few changes from azusa player the chrome extension;
- * mainly to abandon the storageCtxMgr context and use zustand instead. 
+ * mainly to abandon the storageCtxMgr context and use zustand instead.
  * if i'm getting rid of storageCtxMgr there is
  * no point migrating noxplayer storage.js.
  *
@@ -15,7 +16,7 @@ import Song from '../objects/SongInterface';
  * are missing.
  */
 
-// see known storage limits: 
+// see known storage limits:
 // https://react-native-async-storage.github.io/async-storage/docs/limits
 const MAX_SONGLIST_SIZE = 400;
 
@@ -223,7 +224,10 @@ export const initPlayerObject = async (): Promise<PlayerStorageObject> => {
       'NULL',
       'NULL',
     ]),
-    searchPlaylist: dummyPlaylist(),
+    searchPlaylist: dummyPlaylist(
+      'Search',
+      PLAYLIST_ENUMS.TYPE_SEARCH_PLAYLIST
+    ),
     favoriPlaylist: notNullDefault(
       await getItem(STORAGE_KEYS.FAVORITE_PLAYLIST_KEY),
       dummyPlaylist('Favorite', PLAYLIST_ENUMS.TYPE_FAVORI_PLAYLIST)

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,3 +1,5 @@
+import { Alert } from 'react-native';
+
 export const seconds2HHMMSS = (sec_num: number) => {
   const padding = (num: number) => String(num).padStart(2, '0');
   const hours = Math.floor(sec_num / 3600);
@@ -19,4 +21,22 @@ export const seconds2MMSS = (sec_num: number) => {
 export const notNullDefault = (val: any, defaultVal: any) => {
   if (val) return val;
   return defaultVal;
+};
+
+export const twoWayAlert = (
+  title: string,
+  message: string,
+  onSubmit: () => void
+) => {
+  Alert.alert(title, message, [
+    {
+      text: 'Cancel',
+      onPress: () => void 0,
+      style: 'cancel',
+    },
+    {
+      text: 'OK',
+      onPress: onSubmit,
+    },
+  ]);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8026,6 +8026,11 @@ react-native-screens@^3.20.0:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
+react-native-snackbar@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-snackbar/-/react-native-snackbar-2.4.0.tgz#dd9687f5228e379ecd57678a921e546331681bcf"
+  integrity sha512-xEDIDxw0ubBHrsvzaMfrZlFoy+ai1WEJZQwyAsG55fqYxUfQM20h+V4v25u+/H/YKY7ZCRMdCZ8zB5JOnbvCQw==
+
 react-native-tab-view@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-3.5.1.tgz#2ad454afc0e186b43ea8b89053f39180d480d48b"


### PR DESCRIPTION
移植歌单菜单功能：改名，b站识歌，清空歌单，删除歌单，重载歌单，统计，把歌单1加入歌单2

另外的改动：
@kenmingwang 修正settings.gradle和podfile(?)里文件夹改名（example->azusa-player-mobile）；用android Studio重sync和run app后，可以正常运行
progressEmitter in BiliSearchbar.ts 移至zustand store下