### PR TITLE
fix: playback listener mount time

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import Settings from './components/setting/View';
 import './localization/i18n';
 import AppOpenSplash from './components/background/AppOpenSplash';
 import { DummySettings } from './components/setting/View';
+import AzusaPlayer from './AzusaPlayer';
 
 const { LightTheme, DarkTheme } = adaptNavigationTheme({
   reactNavigationLight: NavigationDefaultTheme,
@@ -107,56 +108,58 @@ const App: React.FC = () => {
   // HACK: proof codewhisperer learns stackoverflow:
   // https://stackoverflow.com/questions/54599305/how-to-set-background-image-with-react-native-and-react-navigation
   return (
-    <MainBackground>
-      <PaperProvider
-        theme={{
-          ...defaultTheme,
-          colors: playerStyle.colors,
-        }}
-      >
-        <NavigationContainer
+    <AzusaPlayer>
+      <MainBackground>
+        <PaperProvider
           theme={{
             ...defaultTheme,
-            colors: {
-              ...defaultTheme.colors,
-              ...playerStyle.colors,
-            },
+            colors: playerStyle.colors,
           }}
         >
-          <Drawer.Navigator
-            initialRouteName={ViewEnum.PLAYER_HOME}
-            drawerContent={PlaylistDrawer}
+          <NavigationContainer
+            theme={{
+              ...defaultTheme,
+              colors: {
+                ...defaultTheme.colors,
+                ...playerStyle.colors,
+              },
+            }}
           >
-            <Drawer.Screen
-              name={ViewEnum.PLAYER_HOME}
-              options={{
-                drawerIcon: () => <IconButton icon="home-outline" />,
-                title: String(t('appDrawer.homeScreenName')),
-                header: () => null,
-              }}
-              component={NoxPlayer}
-            />
-            <Drawer.Screen
-              name={ViewEnum.EXPORE}
-              options={{
-                drawerIcon: () => <IconButton icon="compass" />,
-                title: String(t('appDrawer.exploreScreenName')),
-              }}
-              component={DummySettings}
-            />
-            <Drawer.Screen
-              name={ViewEnum.SETTINGS}
-              options={{
-                drawerIcon: () => <IconButton icon="cog" />,
-                title: String(t('appDrawer.settingScreenName')),
-                header: () => null,
-              }}
-              component={Settings}
-            />
-          </Drawer.Navigator>
-        </NavigationContainer>
-      </PaperProvider>
-    </MainBackground>
+            <Drawer.Navigator
+              initialRouteName={ViewEnum.PLAYER_HOME}
+              drawerContent={PlaylistDrawer}
+            >
+              <Drawer.Screen
+                name={ViewEnum.PLAYER_HOME}
+                options={{
+                  drawerIcon: () => <IconButton icon="home-outline" />,
+                  title: String(t('appDrawer.homeScreenName')),
+                  header: () => null,
+                }}
+                component={NoxPlayer}
+              />
+              <Drawer.Screen
+                name={ViewEnum.EXPORE}
+                options={{
+                  drawerIcon: () => <IconButton icon="compass" />,
+                  title: String(t('appDrawer.exploreScreenName')),
+                }}
+                component={DummySettings}
+              />
+              <Drawer.Screen
+                name={ViewEnum.SETTINGS}
+                options={{
+                  drawerIcon: () => <IconButton icon="cog" />,
+                  title: String(t('appDrawer.settingScreenName')),
+                  header: () => null,
+                }}
+                component={Settings}
+              />
+            </Drawer.Navigator>
+          </NavigationContainer>
+        </PaperProvider>
+      </MainBackground>
+    </AzusaPlayer>
   );
 };
 

--- a/src/AzusaPlayer.tsx
+++ b/src/AzusaPlayer.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import useAAPlayback from './hooks/useAAPlayback';
+import { usePlaybackListener } from './hooks/usePlayback';
 
 const AzusaPlayer = (props: any) => {
-  const AAPlayback = useAAPlayback();
+  const playbackListeners = usePlaybackListener();
 
   return <>{props.children}</>;
 };

--- a/src/components/player/TrackInfo/SongMenu.tsx
+++ b/src/components/player/TrackInfo/SongMenu.tsx
@@ -9,6 +9,8 @@ import useUpdatePlaylist from '@hooks/useUpdatePlaylist';
 import { songlistToTracklist } from '@objects/Playlist';
 import { CopiedPlaylistMenuItem } from '../../buttons/CopiedPlaylistButton';
 import { RenameSongMenuItem } from '../../buttons/RenameSongButton';
+import { CIDPREFIX } from '@utils/mediafetch/ytbvideo';
+import logger from '@utils/Logger';
 
 enum ICONS {
   SEND_TO = 'playlist-plus',
@@ -21,6 +23,7 @@ enum ICONS {
   REMOVE = 'delete',
   REMOVE_AND_BAN_BVID = 'delete-forever',
   DETAIL = 'information-outline',
+  RADIO = 'radio-tower',
 }
 
 interface Props {
@@ -32,6 +35,7 @@ interface Props {
   handleSearch?: (val: string) => void;
 }
 
+// TODO: refactro this into tracklist's songmenu
 export default ({
   song,
   songMenuVisible,
@@ -47,6 +51,9 @@ export default ({
   const setCurrentPlayingId = useNoxSetting(state => state.setCurrentPlayingId);
   const setCurrentPlayingList = useNoxSetting(
     state => state.setCurrentPlayingList
+  );
+  const setExternalSearchText = useNoxSetting(
+    state => state.setExternalSearchText
   );
   const { updateSongIndex } = useUpdatePlaylist();
 
@@ -78,11 +85,11 @@ export default ({
     const songs = [song];
     const newPlaylist = banBVID
       ? {
-        ...currentPlaylist2,
-        blacklistedUrl: currentPlaylist2.blacklistedUrl.concat(
-          songs.map(song => song.bvid)
-        ),
-      }
+          ...currentPlaylist2,
+          blacklistedUrl: currentPlaylist2.blacklistedUrl.concat(
+            songs.map(song => song.bvid)
+          ),
+        }
       : currentPlaylist2;
     updatePlaylist(newPlaylist, [], songs);
     setCurrentPlayingList(newPlaylist);
@@ -104,6 +111,14 @@ export default ({
   // track details page, in a seperate stack screen.
   const songInfo = () => {
     closeMenu();
+  };
+  const startRadio = () => {
+    if (song.id.startsWith(CIDPREFIX)) {
+      setExternalSearchText(`youtu.be/list=RD${song.bvid}`);
+    } else {
+      logger.warn(`[startRadio] ${song.bvid} is not a youtube video`);
+    }
+    setSongMenuVisible(false);
   };
 
   return (

--- a/src/components/playlist/BiliSearchbar.tsx
+++ b/src/components/playlist/BiliSearchbar.tsx
@@ -35,6 +35,9 @@ export default ({
   const playerStyle = useNoxSetting(state => state.playerStyle);
   const navigationGlobal = useNavigation();
   const externalSearchText = useNoxSetting(state => state.externalSearchText);
+  const setExternalSearchText = useNoxSetting(
+    state => state.setExternalSearchText
+  );
   const [sharedData, setSharedData] = useState<any>(null);
   const [sharedMimeType, setSharedMimeType] = useState<string | null>(null);
   const { playFromPlaylist } = usePlayback();
@@ -47,6 +50,7 @@ export default ({
   useEffect(() => {
     if (externalSearchText.length > 0) {
       handleExternalSearch(externalSearchText, true);
+      setExternalSearchText('');
     }
   }, [externalSearchText]);
 

--- a/src/components/playlists/View.tsx
+++ b/src/components/playlists/View.tsx
@@ -16,7 +16,6 @@ import DraggableFlatList, {
 
 import { useNoxSetting } from '@hooks/useSetting';
 import useAAPlayback from '@hooks/useAAPlayback';
-import { usePlaybackListener } from '@hooks/usePlayback';
 import { ViewEnum } from '@enums/View';
 import AddPlaylistButton from '../buttons/AddPlaylistButton';
 import { STORAGE_KEYS } from '@utils/ChromeStorage';
@@ -127,7 +126,6 @@ export default (props: any) => {
   // HACK: I know its bad! But somehow this hook isnt updating in its own
   // useEffects...
   const { buildBrowseTree } = useAAPlayback();
-  const playbackListeners = usePlaybackListener();
 
   // HACK: tried to make searchList draweritem button as addPlaylistButton, but
   // dialog disposes on textinput focus. created a dialog directly in this component

--- a/src/services/PlaybackService.ts
+++ b/src/services/PlaybackService.ts
@@ -1,8 +1,20 @@
-import TrackPlayer, { Event, State } from 'react-native-track-player';
+import TrackPlayer, {
+  Event,
+  State,
+  RepeatMode,
+} from 'react-native-track-player';
 
+import { resolveUrl, NULL_TRACK } from '../objects/Song';
+import { initBiliHeartbeat } from '../utils/Bilibili/BiliOperate';
 import type { NoxStorage } from '../types/storage';
 import { saveLastPlayDuration } from '../utils/ChromeStorage';
 import logger from '../utils/Logger';
+import NoxCache from '../utils/Cache';
+import noxPlayingList from '../stores/playingList';
+import { NoxRepeatMode } from '../components/player/enums/RepeatMode';
+
+const { getState } = noxPlayingList;
+let lastBiliHeartBeat: string[] = ['', ''];
 
 export async function AdditionalPlaybackService({
   noInterruption = false,
@@ -55,6 +67,51 @@ export async function PlaybackService() {
 
   TrackPlayer.addEventListener(Event.PlaybackQueueEnded, event => {
     console.log('Event.PlaybackQueueEnded', event);
+  });
+
+  TrackPlayer.addEventListener(Event.PlaybackActiveTrackChanged, event => {
+    console.log('Event.PlaybackActiveTrackChanged', event);
+    if (!event.track || !event.track.song) return;
+    // to resolve bilibili media stream URLs on the fly, TrackPlayer.load is used to
+    // replace the current track's url. its not documented? >:/
+    if (
+      event.index !== undefined &&
+      (event.track.url === NULL_TRACK.url ||
+        new Date().getTime() - event.track.urlRefreshTimeStamp > 3600000)
+    ) {
+      const heartBeatReq = [event.track.song.bvid, event.track.song.id];
+      // HACK: what if cid needs to be resolved on the fly?
+      // TODO: its too much of a hassle and I would like to just
+      // ask users to refresh their lists instead, if they really care
+      // about sending heartbeats.
+      if (
+        lastBiliHeartBeat[0] !== heartBeatReq[0] ||
+        lastBiliHeartBeat[1] !== heartBeatReq[1]
+      ) {
+        initBiliHeartbeat({
+          bvid: event.track.song.bvid,
+          cid: event.track.song.id,
+        });
+        lastBiliHeartBeat = heartBeatReq;
+      }
+      resolveUrl(event.track.song)
+        .then(updatedMetadata => {
+          NoxCache.noxMediaCache?.saveCacheMedia(
+            event.track!.song,
+            updatedMetadata
+          );
+          TrackPlayer.getActiveTrack().then(currentTrack => {
+            TrackPlayer.load({ ...currentTrack, ...updatedMetadata }).then(
+              () => {
+                if (getState().playmode === NoxRepeatMode.REPEAT_TRACK) {
+                  TrackPlayer.setRepeatMode(RepeatMode.Track);
+                }
+              }
+            );
+          });
+        })
+        .catch(e => console.error('resolveURL failed', event.track, e));
+    }
   });
 
   TrackPlayer.addEventListener(Event.PlaybackPlayWhenReadyChanged, event => {


### PR DESCRIPTION
reverts it back to PlaybackService.ts. TrackPlayer when loading the first Track loads too fast before its mounted in a component (it works in debug... not release). 
we can either do this and use a vanilla store to track resolved metadata from PlaybackActiveTrackChanged, or ask TrackPlayer to resolve again at load. second might be a good idea too