### PR TITLE
fix: fade

### DIFF
--- a/src/services/PlaybackService.ts
+++ b/src/services/PlaybackService.ts
@@ -133,7 +133,11 @@ export async function PlaybackService() {
       if (event.track.url !== NULL_TRACK.url) {
         // this is when song is first played.
         logger.debug('[FADEIN] fading in...');
-        await parseSongR128gain(event.track.song, 500, 0);
+        await parseSongR128gain(
+          event.track.song,
+          getAppStoreState().fadeIntervalMs,
+          0
+        );
       }
       // to resolve bilibili media stream URLs on the fly, TrackPlayer.load is used to
       // replace the current track's url. its not documented? >:/

--- a/src/utils/RNTPUtils.ts
+++ b/src/utils/RNTPUtils.ts
@@ -29,6 +29,7 @@ export const animatedVolumeChange = ({
   val = Math.min(val, 1);
   if (duration === 0) {
     animatedVolume.setValue(val);
+    TrackPlayer.setVolume(val);
     callback();
     return;
   }


### PR DESCRIPTION
must turn animated.listener into a headless one too somehow.