### PR TITLE
fix: shuffleAll unique songslist

### DIFF
--- a/src/components/player/controls/WavyAnimation.tsx
+++ b/src/components/player/controls/WavyAnimation.tsx
@@ -20,7 +20,7 @@ const height = 30;
 const frequency = 2;
 const initialAmplitude = 3;
 const initialVerticalOffset = 10;
-const samplingInterval = 10;
+const samplingInterval = 5;
 
 interface Props {
   playing?: boolean;

--- a/src/components/playlist/SongList/SongList.tsx
+++ b/src/components/playlist/SongList/SongList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, BackHandler, StyleSheet } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { IconButton } from 'react-native-paper';
@@ -36,6 +36,14 @@ const PlaylistList = () => {
     playlistRef,
   } = usedPlaylist;
   const netInfo = useNetInfo();
+  const [completeScrollBarHeight, setCompleteScrollBarHeight] = useState(1);
+  const [visibleScrollBarHeight, setVisibleScrollBarHeight] = useState(0.5);
+
+  const scrollIndicatorSize =
+    completeScrollBarHeight > visibleScrollBarHeight
+      ? (visibleScrollBarHeight * visibleScrollBarHeight) /
+        completeScrollBarHeight
+      : visibleScrollBarHeight;
 
   useFocusEffect(
     React.useCallback(() => {
@@ -111,6 +119,32 @@ const PlaylistList = () => {
           onRefresh={refreshPlaylist}
           refreshing={refreshing}
         />
+        <View
+          style={{
+            height: '100%',
+            width: 6,
+            //backgroundColor: '#52057b',
+            borderRadius: 8,
+          }}
+        >
+          <View
+            style={{
+              height: '99%',
+              width: 6,
+              //backgroundColor: '#52057b',
+              borderRadius: 8,
+            }}
+          >
+            <View
+              style={{
+                width: 6,
+                borderRadius: 8,
+                backgroundColor: 'white',
+                height: '50%',
+              }}
+            />
+          </View>
+        </View>
       </View>
       <SongMenu
         usePlaylist={usedPlaylist}

--- a/src/components/playlist/SongList/SongList.tsx
+++ b/src/components/playlist/SongList/SongList.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useRef } from 'react';
-import { View, BackHandler, StyleSheet, Animated } from 'react-native';
+import React from 'react';
+import { View, BackHandler, StyleSheet } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { IconButton } from 'react-native-paper';
 import { useNetInfo } from '@react-native-community/netinfo';
@@ -36,28 +36,6 @@ const PlaylistList = () => {
     playlistRef,
   } = usedPlaylist;
   const netInfo = useNetInfo();
-  const [completeScrollBarHeight, setCompleteScrollBarHeight] = useState(1);
-  const [visibleScrollBarHeight, setVisibleScrollBarHeight] = useState(0);
-  const scrollIndicator = useRef(new Animated.Value(0)).current;
-  const scrollIndicatorSize =
-    completeScrollBarHeight > visibleScrollBarHeight
-      ? (visibleScrollBarHeight * visibleScrollBarHeight) /
-        completeScrollBarHeight
-      : visibleScrollBarHeight;
-
-  const difference =
-    visibleScrollBarHeight > scrollIndicatorSize
-      ? visibleScrollBarHeight - scrollIndicatorSize
-      : 1;
-
-  const scrollIndicatorPosition = Animated.multiply(
-    scrollIndicator,
-    visibleScrollBarHeight / completeScrollBarHeight
-  ).interpolate({
-    inputRange: [0, difference],
-    outputRange: [0, difference],
-    extrapolate: 'clamp',
-  });
 
   useFocusEffect(
     React.useCallback(() => {
@@ -108,20 +86,6 @@ const PlaylistList = () => {
       </View>
       <View style={stylesLocal.playlistContainer}>
         <FlashList
-          onContentSizeChange={height => {
-            setCompleteScrollBarHeight(height);
-          }}
-          onLayout={({
-            nativeEvent: {
-              layout: { height },
-            },
-          }) => {
-            setVisibleScrollBarHeight(height);
-          }}
-          onScroll={Animated.event(
-            [{ nativeEvent: { contentOffset: { y: scrollIndicator } } }],
-            { useNativeDriver: false }
-          )}
           showsVerticalScrollIndicator={false}
           ref={playlistRef}
           data={rows}
@@ -152,20 +116,9 @@ const PlaylistList = () => {
           style={{
             height: '100%',
             width: 6,
-            //backgroundColor: '#52057b',
             borderRadius: 8,
           }}
-        >
-          <Animated.View
-            style={{
-              width: 6,
-              borderRadius: 8,
-              backgroundColor: 'white',
-              height: scrollIndicatorSize,
-              transform: [{ translateY: scrollIndicatorPosition }],
-            }}
-          />
-        </View>
+        ></View>
         <SongMenu
           usePlaylist={usedPlaylist}
           prepareForLayoutAnimationRender={() =>

--- a/src/components/playlist/SongList/SongList.tsx
+++ b/src/components/playlist/SongList/SongList.tsx
@@ -86,7 +86,6 @@ const PlaylistList = () => {
       </View>
       <View style={stylesLocal.playlistContainer}>
         <FlashList
-          showsVerticalScrollIndicator={false}
           ref={playlistRef}
           data={rows}
           renderItem={({ item, index }) => (

--- a/src/hooks/useDataSaver.ts
+++ b/src/hooks/useDataSaver.ts
@@ -1,0 +1,12 @@
+import { useNetInfo } from '@react-native-community/netinfo';
+
+import { useNoxSetting } from '@stores/useApp';
+
+export default () => {
+  const netInfo = useNetInfo();
+  const playerSetting = useNoxSetting(state => state.playerSetting);
+
+  return {
+    isDataSaving: playerSetting.dataSaver && netInfo.type === 'cellular',
+  };
+};

--- a/src/hooks/usePlayback.ts
+++ b/src/hooks/usePlayback.ts
@@ -1,7 +1,6 @@
 import { Platform } from 'react-native';
 import TrackPlayer, { RepeatMode } from 'react-native-track-player';
 import { useTranslation } from 'react-i18next';
-import { useNetInfo } from '@react-native-community/netinfo';
 
 import { useNoxSetting } from '@stores/useApp';
 import { randomChoice } from '../utils/Utils';
@@ -14,6 +13,7 @@ import {
 import { NoxRepeatMode } from '@enums/RepeatMode';
 import noxPlayingList from '@stores/playingList';
 import noxCache from '@utils/Cache';
+import useDataSaver from './useDataSaver';
 
 const PLAYLIST_MEDIAID = 'playlist-';
 
@@ -43,11 +43,7 @@ const usePlayback = () => {
   const setCurrentPlayingList = useNoxSetting(
     state => state.setCurrentPlayingList
   );
-  const netInfo = useNetInfo();
-  const playerSetting = useNoxSetting(state => state.playerSetting);
-
-  const isDataSaving = () =>
-    playerSetting.dataSaver && netInfo.type === 'cellular';
+  const { isDataSaving } = useDataSaver();
 
   const playFromPlaylist = async ({
     playlist,
@@ -93,7 +89,7 @@ const usePlayback = () => {
       }
       playFromPlaylist({
         playlist: playlists[mediaId],
-        playlistParser: dataSaverPlaylistWrapper(isDataSaving()),
+        playlistParser: dataSaverPlaylistWrapper(isDataSaving),
       });
     } else {
       // mediaId should follow the format of ${NoxMedia.Song.bvid}|${NoxMedia.Song.id}
@@ -108,7 +104,7 @@ const usePlayback = () => {
           playFromPlaylist({
             playlist: currentPlayingList,
             song,
-            playlistParser: dataSaverPlaylistWrapper(isDataSaving()),
+            playlistParser: dataSaverPlaylistWrapper(isDataSaving),
           });
           return;
         }
@@ -119,7 +115,7 @@ const usePlayback = () => {
             playFromPlaylist({
               playlist,
               song,
-              playlistParser: dataSaverPlaylistWrapper(isDataSaving()),
+              playlistParser: dataSaverPlaylistWrapper(isDataSaving),
             });
             return;
           }

--- a/src/hooks/useTPControls.ts
+++ b/src/hooks/useTPControls.ts
@@ -22,8 +22,8 @@ const musicTids = [130, 29, 59, 31, 193, 30, 194, 28];
 export default () => {
   const currentPlayingId = useNoxSetting(state => state.currentPlayingId);
   const playerSetting = useNoxSetting(state => state.playerSetting);
-  const findCurrentPlayIndex = () => {
-    return getCurrentTPQueue().findIndex(val => val.id === currentPlayingId);
+  const findCurrentPlayIndex = (queue = getCurrentTPQueue()) => {
+    return queue.findIndex(val => val.id === currentPlayingId);
   };
   const fadeIntervalMs = useStore(appStore, state => state.fadeIntervalMs);
 
@@ -90,10 +90,17 @@ export default () => {
       (await TrackPlayer.getQueue()).length - 1
     ) {
       const currentTPQueue = getCurrentTPQueue();
-      let nextIndex = findCurrentPlayIndex() + 1;
+      let nextIndex = findCurrentPlayIndex(currentTPQueue) + 1;
       if (nextIndex > currentTPQueue.length - 1) {
         nextIndex = 0;
       }
+      console.log(
+        '[debugnext]',
+        nextIndex,
+        currentTPQueue.length,
+        currentTPQueue[nextIndex],
+        currentTPQueue.slice(15, 30)
+      );
       try {
         await skipToBiliSuggest();
       } catch {
@@ -108,7 +115,7 @@ export default () => {
   const prepareSkipToPrevious = async () => {
     if ((await TrackPlayer.getActiveTrackIndex()) === 0) {
       const currentTPQueue = getCurrentTPQueue();
-      let nextIndex = findCurrentPlayIndex() - 1;
+      let nextIndex = findCurrentPlayIndex(currentTPQueue) - 1;
       if (nextIndex < 0) {
         nextIndex = currentTPQueue.length - 1;
       }


### PR DESCRIPTION
because I didnt record the current playing Index but rather determine the index every time via findIndex, this really relies ona songlist's songs being unique on id; this is generally true because updatePlaylist does a songs filter, but not in shuffleAll. this will make playing shuffle all playlist sometimes jumpy as a later song's id was found earlier. 

this is typically not a big problem bc shuffle all is usually a very large playlist; but when filtering to cached songs this is very problematic. theres  not a good workaround, eh. filtering at shuffle all seems slowish (i have 300k song total of playlists). i opted to filter for cached and unique songs when dataSaver is enabled during shuffle all.