### PR TITLE
fix: songlist update view

### DIFF
--- a/src/components/playlist/Menu/PlaylistMenu.tsx
+++ b/src/components/playlist/Menu/PlaylistMenu.tsx
@@ -26,6 +26,7 @@ interface Props {
   toggleVisible?: () => void;
   menuCoords?: NoxTheme.coordinates;
   playlist: NoxMedia.Playlist;
+  songListUpdateHalt: () => void;
 }
 
 export default ({
@@ -33,6 +34,7 @@ export default ({
   toggleVisible = () => undefined,
   menuCoords = { x: 0, y: 0 },
   playlist,
+  songListUpdateHalt,
 }: Props) => {
   const { t } = useTranslation();
   const {
@@ -56,12 +58,15 @@ export default ({
       />
       <CopiedPlaylistMenuItem
         getFromListOnClick={() => playlist}
-        onSubmit={() => toggleVisible()}
+        onSubmit={toggleVisible}
       />
       <PlaylistSortButton
-        sortPlaylist={sortPlaylist}
+        sortPlaylist={(o, a, p) => {
+          songListUpdateHalt();
+          sortPlaylist(o, a, p);
+        }}
         playlist={playlist}
-        onCancel={() => toggleVisible()}
+        onCancel={toggleVisible}
       />
       <Menu.Item
         leadingIcon={ICONS.BILISYNC}

--- a/src/components/playlist/Menu/PlaylistMenuButton.tsx
+++ b/src/components/playlist/Menu/PlaylistMenuButton.tsx
@@ -9,9 +9,10 @@ const ICON = 'dots-horizontal';
 interface Props {
   disabled?: boolean;
   playlist: NoxMedia.Playlist;
+  songListUpdateHalt: () => void;
 }
 
-export default ({ disabled = false, playlist }: Props) => {
+export default ({ disabled = false, playlist, songListUpdateHalt }: Props) => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [menuCoords, setMenuCoords] = useState<NoxTheme.coordinates>({
     x: 0,
@@ -43,6 +44,7 @@ export default ({ disabled = false, playlist }: Props) => {
         toggleVisible={toggleVisible}
         menuCoords={menuCoords}
         playlist={playlist}
+        songListUpdateHalt={songListUpdateHalt}
       />
     </React.Fragment>
   );

--- a/src/components/playlist/SongList/SongList.tsx
+++ b/src/components/playlist/SongList/SongList.tsx
@@ -23,6 +23,7 @@ const PlaylistList = () => {
     refreshPlaylist,
     refreshing,
     rows,
+    setRows,
     toggleSelected,
     toggleSelectedAll,
     shouldReRender,
@@ -81,7 +82,11 @@ const PlaylistList = () => {
                 : undefined
             }
           />
-          <PlaylistMenuButton disabled={checking} playlist={currentPlaylist} />
+          <PlaylistMenuButton
+            disabled={checking}
+            playlist={currentPlaylist}
+            songListUpdateHalt={() => setRows([])}
+          />
         </View>
       </View>
       <View style={stylesLocal.playlistContainer}>

--- a/src/components/setting/GeneralSettings.tsx
+++ b/src/components/setting/GeneralSettings.tsx
@@ -54,7 +54,9 @@ export default () => {
       }}
     >
       <ScrollView>
-        {GEN_SETTING_BOOLEAN.map(item => RenderSetting({ item }))}
+        {GEN_SETTING_BOOLEAN.map(item => (
+          <RenderSetting item={item} key={item.settingName} />
+        ))}
       </ScrollView>
     </View>
   );


### PR DESCRIPTION
prevent a recyclingview? bug where the previous content is lingering in flashlist somehow, by setting the data to empty beforehand to clear content first. performance hit is beyter than a bug