### PR TITLE
fix: expose playURL error to RNTP

### DIFF
--- a/src/utils/mediafetch/resolveURL.ts
+++ b/src/utils/mediafetch/resolveURL.ts
@@ -53,6 +53,7 @@ export const fetchPlayUrlPromise = async (
     }
     return fetchVideoPlayUrlPromise({ bvid, cid: cidStr, iOS });
   };
+
   if (v.source && Object.values(MUSICFREE).includes(v.source as MUSICFREE)) {
     const vsource = v.source as MUSICFREE;
     const result = await resolver[vsource](v);
@@ -69,7 +70,7 @@ export const fetchPlayUrlPromise = async (
     regexOperations: regexResolveURLsWrapped,
     fallback,
     regexMatching: song => song.id,
-  });
+  }).catch(() => ({ url: 'NULL' }));
 };
 
 export const refreshMetadata = async (


### PR DESCRIPTION
closes #419 
exposes fetchPlayUrlPromise onError to a null track that gives an error in RNTP. 