### PR TITLE
feat: resolveArtwork native

### DIFF
--- a/android/app/src/main/java/com/noxplay/noxplayer/NoxAndroidAutoModule.kt
+++ b/android/app/src/main/java/com/noxplay/noxplayer/NoxAndroidAutoModule.kt
@@ -197,6 +197,6 @@ class NoxAndroidAutoModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod fun getAPMCacheUri(callback: Promise) {
-    callback.resolve(getAPMCacheUriNative())
+    callback.resolve(getAPMCacheUriNative().toString())
   }
 }

--- a/android/app/src/main/java/com/noxplay/noxplayer/NoxAndroidAutoModule.kt
+++ b/android/app/src/main/java/com/noxplay/noxplayer/NoxAndroidAutoModule.kt
@@ -1,5 +1,6 @@
 package com.noxplay.noxplayer
 
+import android.annotation.SuppressLint
 import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import android.content.ContentUris
@@ -9,9 +10,10 @@ import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import android.provider.Settings
-import android.util.Log
 import android.view.WindowManager
 import androidx.core.content.FileProvider
+import com.doublesymmetry.kotlinaudio.utils.bitmapCoverDir
+import com.doublesymmetry.kotlinaudio.utils.bitmapCoverFileName
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -19,6 +21,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableNativeArray
+import timber.log.Timber
 import java.io.File
 
 
@@ -26,7 +29,7 @@ class NoxAndroidAutoModule(reactContext: ReactApplicationContext) :
   ReactContextBaseJavaModule(reactContext) {
   override fun getName() = "NoxAndroidAutoModule"
 
-  private fun _listMediaDir(relativeDir: String, subdir: Boolean, selection: String? = null): WritableArray {
+  private fun listMediaDirNative(relativeDir: String, subdir: Boolean, selection: String? = null): WritableArray {
     val results: WritableArray = WritableNativeArray()
     try {
       val query = reactApplicationContext.contentResolver.query(
@@ -79,7 +82,7 @@ class NoxAndroidAutoModule(reactContext: ReactApplicationContext) :
         }
       }
     } catch (e: Exception) {
-      Log.e("NoxFileUtil", e.toString())
+      Timber.tag("NoxFileUtil").e(e.toString())
     }
     return results
   }
@@ -90,16 +93,16 @@ class NoxAndroidAutoModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod fun listMediaDir(relativeDir: String, subdir: Boolean, callback: Promise) {
-    callback.resolve(_listMediaDir(relativeDir, subdir))
+    callback.resolve(listMediaDirNative(relativeDir, subdir))
   }
 
   @ReactMethod fun listMediaFileByFName(filename: String, callback: Promise) {
-    callback.resolve(_listMediaDir("", true,
+    callback.resolve(listMediaDirNative("", true,
       "${MediaStore.Audio.Media.DISPLAY_NAME} IN ('$filename')"))
   }
 
   @ReactMethod fun listMediaFileByID(id: String, callback: Promise) {
-    callback.resolve(_listMediaDir("", true,
+    callback.resolve(listMediaDirNative("", true,
       "${MediaStore.Audio.Media._ID} = $id"))
   }
   @ReactMethod fun getLastExitReason(callback: Promise) {
@@ -171,5 +174,29 @@ class NoxAndroidAutoModule(reactContext: ReactApplicationContext) :
     callback.resolve(
       Settings.Secure.getInt(context.contentResolver, "navigation_mode", 0) == 2
     )
+  }
+
+  @SuppressLint("Range")
+  private fun getAPMCacheUriNative(contentUri: Uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI): Uri? {
+    val contentResolver = reactApplicationContext.contentResolver
+    val selection = "${MediaStore.MediaColumns.RELATIVE_PATH}=?"
+    val selectionArgs = arrayOf(bitmapCoverDir)
+    val cursor = contentResolver.query(contentUri, null, selection,selectionArgs,null)
+    if (cursor != null && cursor.count > 0) {
+      while (cursor.moveToNext()) {
+        val filename = cursor.getString(cursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME))
+        if (filename == bitmapCoverFileName) {
+          val id = cursor.getLong(cursor.getColumnIndex(MediaStore.MediaColumns._ID))
+          cursor.close()
+          return ContentUris.withAppendedId(contentUri, id)
+        }
+      }
+      cursor.close()
+    }
+    return null
+  }
+
+  @ReactMethod fun getAPMCacheUri(callback: Promise) {
+    callback.resolve(getAPMCacheUriNative())
   }
 }

--- a/src/components/setting/DeveloperSettings.tsx
+++ b/src/components/setting/DeveloperSettings.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { View, ScrollView, Platform } from 'react-native';
 import { List } from 'react-native-paper';
-import i18n from 'i18next';
 import { useTranslation } from 'react-i18next';
-// eslint-disable-next-line import/no-unresolved
-import { APPSTORE } from '@env';
 import { useStore } from 'zustand';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as Sentry from '@sentry/react-native';
 
+// eslint-disable-next-line import/no-unresolved
+import { APPSTORE } from '@env';
 import { useNoxSetting } from '@stores/useApp';
 import { logStore, LOGLEVEL } from '@utils/Logger';
 import GenericSelectDialog from '../dialogs/GenericSelectDialog';
@@ -47,15 +46,6 @@ enum VIEW {
 const Stack = createNativeStackNavigator();
 
 const FadeOptions = [0, 250, 500, 1000];
-
-const logLevelString = [
-  i18n.t('DeveloperSettings.LogLevel0'),
-  i18n.t('DeveloperSettings.LogLevel1'),
-  i18n.t('DeveloperSettings.LogLevel2'),
-  i18n.t('DeveloperSettings.LogLevel3'),
-  i18n.t('DeveloperSettings.LogLevel4'),
-  i18n.t('DeveloperSettings.LogLevel5'),
-];
 
 const developerSettings: { [key: string]: SettingEntry } = {
   noInterruption: {
@@ -100,6 +90,16 @@ const Home = ({ navigation }: NoxComponent.NavigationProps) => {
   const { orphanedCache, cleanOrphanedCache } = useCleanCache();
   const fadeIntervalMs = useStore(appStore, state => state.fadeIntervalMs);
 
+  // HACK: doesnt render on my phone?!
+  const logLevelString = [
+    t('DeveloperSettings.LogLevel0'),
+    t('DeveloperSettings.LogLevel1'),
+    t('DeveloperSettings.LogLevel2'),
+    t('DeveloperSettings.LogLevel3'),
+    t('DeveloperSettings.LogLevel4'),
+    t('DeveloperSettings.LogLevel5'),
+  ];
+
   const selectLogLevel = () => {
     setSelectVisible(true);
     setCurrentSelectOption({
@@ -118,7 +118,7 @@ const Home = ({ navigation }: NoxComponent.NavigationProps) => {
         setState({ logLevel: index });
         setSelectVisible(false);
       },
-      title: t('DeveloperSettings.LogLevel'),
+      title: t('DeveloperSettings.LogLevelName'),
     } as SelectSettingEntry<number>);
   };
 

--- a/src/enums/Storage.ts
+++ b/src/enums/Storage.ts
@@ -70,7 +70,7 @@ export const DefaultSetting: NoxStorage.PlayerSettingDict = {
   keepForeground: false,
   karaokeLyrics: false,
   accentColor: false,
-  memoryEfficiency: false,
+  memoryEfficiency: true,
   useSuggestion: false,
 
   appID: AppID,

--- a/src/utils/mediafetch/local.ts
+++ b/src/utils/mediafetch/local.ts
@@ -68,6 +68,10 @@ const resolveURL = async (song: NoxMedia.Song) => {
 
 const resolveArtwork = async (song: NoxMedia.Song) => {
   try {
+    if (Platform.OS === 'android') {
+      const APMCacheUri = await NoxAndroidAutoModule.getAPMCacheUri();
+      if (APMCacheUri !== null) return APMCacheUri;
+    }
     const artworkUri = await cacheAlbumArt(song.bvid);
     if (artworkUri) {
       return base64AlbumArt(artworkUri);


### PR DESCRIPTION
skips ffmpeg resolve local artwork if possible, since the embedded image is being cached to /Pictures anyways.