### PR TITLE
fix: ytbi thumbnail resolve

### DIFF
--- a/src/hooks/useSetupPlayer.ts
+++ b/src/hooks/useSetupPlayer.ts
@@ -12,7 +12,6 @@ import useInitializeStore from '@stores/initializeStores';
 import { IntentData } from '@enums/Intent';
 import { useNoxSetting } from '@stores/useApp';
 import usePlayStore from './usePlayStore';
-import { awaitYtbiSetup } from '../utils/mediafetch/ytbi';
 
 const { NoxAndroidAutoModule } = NativeModules;
 
@@ -25,7 +24,6 @@ export default ({ intentData }: NoxComponent.AppProps) => {
   const { checkPlayStoreUpdates } = usePlayStore();
 
   useEffect(() => {
-    awaitYtbiSetup();
     let unmounted = false;
     (async () => {
       const {

--- a/src/utils/mediafetch/ytbSearch.ytbi.ts
+++ b/src/utils/mediafetch/ytbSearch.ytbi.ts
@@ -17,7 +17,6 @@ export const ytbiVideoToNoxSong = (val: Video) => {
     lyric: '',
     page: 1,
     duration: val.duration.seconds,
-    album: 'ytbSearch',
     source: Source.ytbvideo,
     metadataOnLoad: true,
   });

--- a/src/utils/mediafetch/ytbi.ts
+++ b/src/utils/mediafetch/ytbi.ts
@@ -39,8 +39,8 @@ global.CustomEvent = CustomEvent as any;
 
 // === END === Making Youtube.js work
 
-const ytClient: Promise<Innertube> = Innertube.create({
-  retrieve_player: false,
+const ytClient = Innertube.create({
+  retrieve_player: true,
   enable_session_cache: false,
   generate_session_locally: false,
   client_type: ClientType.IOS,
@@ -48,7 +48,7 @@ const ytClient: Promise<Innertube> = Innertube.create({
 
 export default ytClient;
 
-export const ytClientWeb: Promise<Innertube> = Innertube.create({
+export const ytClientWeb = Innertube.create({
   retrieve_player: false,
   enable_session_cache: false,
   generate_session_locally: false,

--- a/src/utils/mediafetch/ytbi.ts
+++ b/src/utils/mediafetch/ytbi.ts
@@ -39,21 +39,14 @@ global.CustomEvent = CustomEvent as any;
 
 // === END === Making Youtube.js work
 
-let ytClient: Promise<Innertube>;
+const ytClient: Promise<Innertube> = Innertube.create({
+  retrieve_player: false,
+  enable_session_cache: false,
+  generate_session_locally: false,
+  client_type: ClientType.IOS,
+});
 
-export const resetYtClient = (retrievePlayer = false) => {
-  ytClient = Innertube.create({
-    retrieve_player: retrievePlayer,
-    enable_session_cache: false,
-    generate_session_locally: false,
-    client_type: ClientType.IOS,
-  });
-  return ytClient;
-};
-
-resetYtClient();
-
-export default () => ytClient;
+export default ytClient;
 
 export const ytClientWeb: Promise<Innertube> = Innertube.create({
   retrieve_player: false,

--- a/src/utils/mediafetch/ytbvideo.ts
+++ b/src/utils/mediafetch/ytbvideo.ts
@@ -11,7 +11,7 @@ import {
 } from './ytbvideo.muse';
 
 const resolveURL = (song: NoxMedia.Song, iOS = false) =>
-  resolveURLYtbi(song, iOS).catch(() => resolveURLMuse(song));
+  resolveURLMuse(song).catch(() => resolveURLYtbi(song, iOS));
 
 export const fetchAudioInfo = (bvid: string, progressEmitter?: () => void) =>
   biliApiLimiter.schedule(() => {

--- a/src/utils/mediafetch/ytbvideo.ytbi.ts
+++ b/src/utils/mediafetch/ytbvideo.ytbi.ts
@@ -1,7 +1,7 @@
 import SongTS from '@objects/Song';
 import { Source } from '@enums/MediaFetch';
 import { logger } from '@utils/Logger';
-import ytClient from '@utils/mediafetch/ytbi';
+import ytClient, { ytClientWeb } from '@utils/mediafetch/ytbi';
 import { isIOS } from '@utils/RNUtils';
 import { Thumbnail } from 'youtubei.js/dist/src/parser/misc';
 
@@ -30,8 +30,8 @@ export const resolveURL = async (song: NoxMedia.Song, iOS = false) => {
 };
 
 export const fetchAudioInfo = async (sid: string) => {
-  const yt = await ytClient;
-  const videoInfo = (await yt.getBasicInfo(sid, 'IOS')).basic_info;
+  const yt = await ytClientWeb;
+  const videoInfo = (await yt.getBasicInfo(sid)).basic_info;
   return [
     SongTS({
       cid: `${Source.ytbvideo}-${sid}`,

--- a/src/utils/mediafetch/ytbvideo.ytbi.ts
+++ b/src/utils/mediafetch/ytbvideo.ytbi.ts
@@ -1,7 +1,7 @@
 import SongTS from '@objects/Song';
 import { Source } from '@enums/MediaFetch';
 import { logger } from '@utils/Logger';
-import ytClient, { resetYtClient } from '@utils/mediafetch/ytbi';
+import ytClient from '@utils/mediafetch/ytbi';
 import { isIOS } from '@utils/RNUtils';
 import { Thumbnail } from 'youtubei.js/dist/src/parser/misc';
 
@@ -10,46 +10,27 @@ const getHiResThumbnail = (thumbnails?: Thumbnail[]) => {
   return thumbnails.sort((a, b) => b.width - a.width)[0]!.url;
 };
 
-interface ResolveURL {
-  song: NoxMedia.Song;
-  iOS?: boolean;
-  reset?: boolean;
-}
-
-const _resolveURL = async ({
-  song,
-  iOS = false,
-  reset = false,
-}: ResolveURL): Promise<NoxNetwork.ParsedNoxMediaURL> => {
+export const resolveURL = async (song: NoxMedia.Song, iOS = false) => {
   logger.debug(`[ytbi.js] fetch YTB playURL promise:${song.bvid}`);
-  const yt = await ytClient();
+  const yt = await ytClient;
   const extractedVideoInfo = await yt.getBasicInfo(song.bvid, 'IOS');
   const maxAudioQualityStream = extractedVideoInfo.chooseFormat({
     quality: 'best',
     type: 'audio',
   });
   const thumbnails = extractedVideoInfo.basic_info.thumbnail;
-  const url =
-    iOS && isIOS && extractedVideoInfo.streaming_data?.hls_manifest_url
-      ? extractedVideoInfo.streaming_data?.hls_manifest_url
-      : maxAudioQualityStream.decipher(yt.actions.session.player);
-  if (url || reset) {
-    return {
-      url,
-      cover: getHiResThumbnail(thumbnails),
-      loudness: maxAudioQualityStream.loudness_db,
-    };
-  }
-  logger.warn('[ytbi] resetting ytClient to retrive player. This takes time.');
-  await resetYtClient();
-  return _resolveURL({ song, iOS, reset: true });
+  return {
+    url:
+      iOS && isIOS && extractedVideoInfo.streaming_data?.hls_manifest_url
+        ? extractedVideoInfo.streaming_data?.hls_manifest_url
+        : maxAudioQualityStream.decipher(yt.actions.session.player),
+    cover: getHiResThumbnail(thumbnails),
+    loudness: maxAudioQualityStream.loudness_db,
+  };
 };
 
-export const resolveURL = async (song: NoxMedia.Song, iOS = false) =>
-  _resolveURL({ song, iOS });
-
 export const fetchAudioInfo = async (sid: string) => {
-  const yt = await ytClient();
+  const yt = await ytClient;
   const videoInfo = (await yt.getBasicInfo(sid, 'IOS')).basic_info;
   return [
     SongTS({


### PR DESCRIPTION
ytbi init (retrieve_player) must be true. i thought its not necessary bc it is caught by using ytm to resolve. 

so ytm will now be used to resolve by default; and a new function separate from resolveURL to refresh metadata is added. for some reason ytm's metadata (really, cover) is not highres.