### PR TITLE
fix: miniplayer drag performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "react-native-carplay": "2.4.1-beta.0",
     "react-native-device-info": "^14.0.4",
     "react-native-edge-to-edge": "^1.6.2",
-    "react-native-flashdrag-list": "https://lovegaoshi@github.com/lovegaoshi/react-native-flashdrag-list.git#commit=73857bd7931378589e85fcfcfc526847b0be03d4",
+    "react-native-flashdrag-list": "https://lovegaoshi@github.com/lovegaoshi/react-native-flashdrag-list.git#commit=2810c87b1e9ba19ba7102f54fd91222109dcacad",
     "react-native-gesture-handler": "~2.25.0",
     "react-native-get-random-values": "^1.11.0",
     "react-native-image-colors": "^2.4.0",

--- a/src/components/playlists/Playlists.tsx
+++ b/src/components/playlists/Playlists.tsx
@@ -179,25 +179,23 @@ export default () => {
         onClose={() => setNewPlaylistDialogOpen(false)}
         onSubmit={() => setNewPlaylistDialogOpen(false)}
       />
-      <View style={{ flex: 1 }}>
-        <FlashDragList
-          data={playlistIds}
-          renderItem={renderItem}
-          itemsSize={53}
-          onSort={(fromIndex, toIndex) => {
-            const copy = [...playlistIds];
-            const removed = copy.splice(fromIndex, 1);
-            copy.splice(toIndex, 0, removed[0]!);
-            setPlaylistIds(copy);
-          }}
-          extraData={[
-            currentPlaylist.id,
-            currentPlayingList.id,
-            currentPlaylist.title,
-            playerStyle,
-          ]}
-        />
-      </View>
+      <FlashDragList
+        data={playlistIds}
+        renderItem={renderItem}
+        itemsSize={53}
+        onSort={(fromIndex, toIndex) => {
+          const copy = [...playlistIds];
+          const removed = copy.splice(fromIndex, 1);
+          copy.splice(toIndex, 0, removed[0]!);
+          setPlaylistIds(copy);
+        }}
+        extraData={[
+          currentPlaylist.id,
+          currentPlayingList.id,
+          currentPlaylist.title,
+          playerStyle,
+        ]}
+      />
       <View style={styles.bottomInfo}>
         <Text style={styles.bottomInfoText}>
           {`${playerStyle.metaData.themeName} @ ${playerSetting.noxVersion}`}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7773,7 +7773,7 @@ __metadata:
     react-native-device-info: "npm:^14.0.4"
     react-native-dotenv: "npm:^3.4.11"
     react-native-edge-to-edge: "npm:^1.6.2"
-    react-native-flashdrag-list: "https://lovegaoshi@github.com/lovegaoshi/react-native-flashdrag-list.git#commit=73857bd7931378589e85fcfcfc526847b0be03d4"
+    react-native-flashdrag-list: "https://lovegaoshi@github.com/lovegaoshi/react-native-flashdrag-list.git#commit=2810c87b1e9ba19ba7102f54fd91222109dcacad"
     react-native-gesture-handler: "npm:~2.25.0"
     react-native-get-random-values: "npm:^1.11.0"
     react-native-image-colors: "npm:^2.4.0"
@@ -18710,16 +18710,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-flashdrag-list@https://lovegaoshi@github.com/lovegaoshi/react-native-flashdrag-list.git#commit=73857bd7931378589e85fcfcfc526847b0be03d4":
+"react-native-flashdrag-list@https://lovegaoshi@github.com/lovegaoshi/react-native-flashdrag-list.git#commit=2810c87b1e9ba19ba7102f54fd91222109dcacad":
   version: 0.2.5
-  resolution: "react-native-flashdrag-list@https://lovegaoshi@github.com/lovegaoshi/react-native-flashdrag-list.git#commit=73857bd7931378589e85fcfcfc526847b0be03d4"
+  resolution: "react-native-flashdrag-list@https://lovegaoshi@github.com/lovegaoshi/react-native-flashdrag-list.git#commit=2810c87b1e9ba19ba7102f54fd91222109dcacad"
   peerDependencies:
     "@shopify/flash-list": "*"
     react: "*"
     react-native: "*"
     react-native-gesture-handler: "*"
     react-native-reanimated: "*"
-  checksum: 10c0/1ea22bbc5765a947f08be6ada5830a1128778f7168e1a22c2c6a9cdcb46ee7e4ab05e2bf2b2b7119b580bc9e6512e2c50a7950844f9abd911e69a9b26dde8db1
+  checksum: 10c0/3666b0a0f9c95d9e14e8b8728c989d747a4687a55fef7dfe80b90fbc0da5992a403e936693ab78279df0a38e512d56386f88ed0e8ffcec2cfd3efca55b7b36f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #1015 

issue here is miniplayer drag causes layout calculations and is slow when theere is a flexview in a drawer. i dont know why the view height isnt fixed here but once its removed miniplayer becomes fluid again. so the current solution is to NOT render the drawer (or at least the performance sensitive flashlist part)