### PR TITLE
fix: crossfade

### DIFF
--- a/src/components/player/controls/usePlayerControls.ts
+++ b/src/components/player/controls/usePlayerControls.ts
@@ -10,7 +10,7 @@ import useTPControls from '@hooks/useTPControls';
 import { saveLastPlayDuration } from '@utils/ChromeStorage';
 import { logger } from '@utils/Logger';
 import appStore, { setCurrentPlaying, setCrossfaded } from '@stores/appStore';
-import noxPlayingList from '@stores/playingList';
+import noxPlayingList, { playNextIndex } from '@stores/playingList';
 import { NoxRepeatMode } from '@enums/RepeatMode';
 import usePlaylistCRUD from '@hooks/usePlaylistCRUD';
 import { getR128Gain, getABRepeat } from '@utils/db/sqlAPI';
@@ -87,7 +87,7 @@ export default () => {
       logger.debug(
         `[crossfade] preparing crossfade at ${event.position}/${event.duration}`,
       );
-      await prepareSkipToNext();
+      await prepareSkipToNext(false);
       setCrossfadeId(track?.song?.id ?? '');
       setBRepeatDuration(event.duration * abRepeat[1]);
       return TrackPlayer.crossFadePrepare();
@@ -114,6 +114,9 @@ export default () => {
         setCrossfadingId(currentSongId);
         setCrossfadeId('');
         setCrossfaded(true);
+        // HACK: manually update playing index.
+        // this needs to be refactored at some point (eg setting index hooked inside useActiveTrack)
+        playNextIndex({});
         return TrackPlayer.crossFade(
           playerSetting.crossfade * 1000,
           20,

--- a/src/hooks/usePlayback.migrate.ts
+++ b/src/hooks/usePlayback.migrate.ts
@@ -65,6 +65,7 @@ export const _playFromPlaylist = async ({
       song = randomChoice(playlist.songList);
     }
   }
+  logger.debug(`[playfromPlaylist] playing ${song.id} from ${playlist.id}`);
   setPlayingIndex(0, song.id);
   setCurrentPlayingId(song.id);
   logger.debug(

--- a/src/hooks/useTPControls.ts
+++ b/src/hooks/useTPControls.ts
@@ -37,9 +37,12 @@ const skipToBiliSuggest = async (
   await TrackPlayer.add(await songlistToTracklist(suggestedSong), 0);
 };
 
-const prepareSkipToNext = async (mSkipToBiliSuggest = skipToBiliSuggest) => {
+const prepareSkipToNext = async (
+  mSkipToBiliSuggest = skipToBiliSuggest,
+  set = true,
+) => {
   const TPQueueLength = (await TrackPlayer.getQueue()).length;
-  const nextSong = playNextSong();
+  const nextSong = playNextSong(undefined, set);
   if ((await TrackPlayer.getActiveTrackIndex()) === TPQueueLength - 1) {
     const { playerSetting } = useNoxSetting.getState();
     autoShuffleQueue(
@@ -141,7 +144,8 @@ export default () => {
   return {
     performFade: (callback: () => void) =>
       performFade(callback, fadeIntervalMs),
-    prepareSkipToNext: () => prepareSkipToNext(mSkipToBiliSuggest),
+    prepareSkipToNext: (set = true) =>
+      prepareSkipToNext(mSkipToBiliSuggest, set),
     performSkipToNext: (auto = false) =>
       performSkipToNext(
         auto,

--- a/src/stores/playingList.ts
+++ b/src/stores/playingList.ts
@@ -43,6 +43,9 @@ export const setPlayingIndex = (index = 0, songId?: string) => {
       return;
     }
   }
+  logger.debug(
+    `[setPlayingIndex] moving playing index to ${index} / ${songId}`,
+  );
   playlistStore.setState({
     currentPlayingIndex: index,
     currentPlayingId: songId,
@@ -50,13 +53,13 @@ export const setPlayingIndex = (index = 0, songId?: string) => {
 };
 
 interface PlayNextIndex {
-  direction: number;
-  set: boolean;
+  direction?: number;
+  set?: boolean;
 }
 /**
  * WARN: actually moves currentPlayingIndex
  */
-const playNextIndex = ({ direction = 1, set = true }: PlayNextIndex) => {
+export const playNextIndex = ({ direction = 1, set = true }: PlayNextIndex) => {
   const { currentPlayingIndex, playingList } = playlistStore.getState();
   let newIndex = currentPlayingIndex + direction;
   if (newIndex < 0) {
@@ -64,6 +67,7 @@ const playNextIndex = ({ direction = 1, set = true }: PlayNextIndex) => {
   } else if (newIndex >= playingList.length) {
     newIndex = 0;
   }
+  logger.debug(`[playNextIndex] moving to ${newIndex}, ${set}`);
   if (set) setPlayingIndex(newIndex);
   return newIndex;
 };


### PR DESCRIPTION
need to refactor the playback logic. so now the play next logic is dictated by playingList store's currentPlayingIndex

previously playNext/Previous is done by moving the playback index, get the song, insert if needed, then TP.skipToNext/Previous. with crossfade it pre-inserts the song but to get the song it moves the playback index as well, making crossfade jumping around the queue by quite a lot. here the TP.crossfadePrepare is updated to NOT move the playback index, but rather the index moving is happing at TP.crossfade

its still a rather inconsistent solution that will bite me in the butt later