### PR TITLE
feat: pull up to refresh

### DIFF
--- a/src/components/commonui/RefreshIndicator.tsx
+++ b/src/components/commonui/RefreshIndicator.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { LayoutRectangle, Text } from 'react-native';
+import Animated, {
+  interpolate,
+  runOnJS,
+  SharedValue,
+  useAnimatedReaction,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+
+interface IndicatorProps {
+  pullDistanceValue: number;
+}
+const DebugIndicator = ({ pullDistanceValue }: IndicatorProps) => {
+  return (
+    <Text style={{ backgroundColor: 'black', color: 'white' }}>
+      {pullDistanceValue.toFixed(2)}
+    </Text>
+  );
+};
+
+interface Props {
+  pullUpDistance: SharedValue<number>;
+  layout?: LayoutRectangle;
+  indicatorOffset?: number;
+  pullRange?: number;
+  Indicator?: ({ pullDistanceValue }: IndicatorProps) => JSX.Element;
+}
+
+export default ({
+  pullUpDistance,
+  layout,
+  indicatorOffset = -50,
+  pullRange = -100,
+  Indicator = DebugIndicator,
+}: Props) => {
+  const [value, setValue] = useState(0);
+
+  useAnimatedReaction(
+    () => pullUpDistance.value,
+    curr => {
+      runOnJS(setValue)(curr);
+    },
+  );
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateY: interpolate(pullUpDistance.value, [0, pullRange], [0, -20]),
+      },
+    ],
+    opacity: interpolate(pullUpDistance.value, [0, pullRange], [0, 1]),
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        {
+          position: 'absolute',
+          alignItems: 'center',
+          left: 0,
+          width: layout?.width ?? 0,
+          top: (layout?.height ?? -999) + indicatorOffset,
+        },
+        animatedStyle,
+      ]}
+      onLayout={e => console.log('scrollindicatorlayout', e.nativeEvent.layout)}
+    >
+      <Indicator pullDistanceValue={value} />
+    </Animated.View>
+  );
+};

--- a/src/components/commonui/RefreshIndicator.tsx
+++ b/src/components/commonui/RefreshIndicator.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { LayoutRectangle, Text, View, ViewStyle } from 'react-native';
+import { LayoutRectangle, Text, View } from 'react-native';
 import { Icon } from 'react-native-paper';
 import Animated, {
   interpolate,

--- a/src/components/explore/SongTab.tsx
+++ b/src/components/explore/SongTab.tsx
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
+import { LegendList } from '@legendapp/list';
 import { Image } from 'expo-image';
 import { useTranslation } from 'react-i18next';
 
@@ -50,7 +50,7 @@ export const BiliSongCard = ({
       ]}
     >
       {title && <Text style={{ fontSize: 20, color: fontColor }}>{title}</Text>}
-      <FlashList
+      <LegendList
         estimatedItemSize={390}
         showsVerticalScrollIndicator={false}
         data={songs}

--- a/src/components/explore/View.tsx
+++ b/src/components/explore/View.tsx
@@ -12,7 +12,6 @@ import { useAPM } from '@stores/usePersistStore';
 import FlexView from '@components/commonui/FlexViewNewArch';
 import AutoUnmountNavView from '../commonui/AutoUnmountNavView';
 import { useIsLandscape } from '@hooks/useOrientation';
-import DelayedComponent from '../commonui/DelayedComponent';
 
 const LoginComponent = ({ loginSite }: { loginSite: Site }) => {
   switch (loginSite) {

--- a/src/components/playlist/SongList/SongList.tsx
+++ b/src/components/playlist/SongList/SongList.tsx
@@ -1,13 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { LayoutRectangle, NativeScrollEvent, Text, View } from 'react-native';
+import { LayoutRectangle, NativeScrollEvent } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useNetInfo } from '@react-native-community/netinfo';
 import Animated, {
   runOnJS,
   SharedValue,
-  useAnimatedReaction,
   useAnimatedScrollHandler,
-  useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
 } from 'react-native-reanimated';
@@ -23,7 +21,7 @@ import SongBackground from './SongBackground';
 import { useNoxSetting } from '@stores/useApp';
 import keepAwake from '@utils/keepAwake';
 import { UsePlaylistRN } from '../usePlaylistRN';
-import { pull } from 'lodash';
+import RefreshIndicator from '@components/commonui/RefreshIndicator';
 
 const AnimatedFlashList = Animated.createAnimatedComponent(
   FlashList<NoxMedia.Song>,
@@ -242,51 +240,11 @@ export default ({
           showsVerticalScrollIndicator={false}
           onScroll={scrollHandler}
         />
-        <PullUpIndicator
+        <RefreshIndicator
           pullUpDistance={pullUpDistance}
           layout={flashlistLayout}
         />
       </>
     </GestureDetector>
-  );
-};
-
-const PullUpIndicator = ({
-  pullUpDistance,
-  layout,
-}: {
-  pullUpDistance: SharedValue<number>;
-  layout?: LayoutRectangle;
-}) => {
-  const [value, setValue] = useState(0);
-
-  useAnimatedReaction(
-    () => pullUpDistance.value,
-    curr => {
-      runOnJS(setValue)(curr);
-    },
-  );
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: pullUpDistance.value }],
-  }));
-
-  return (
-    <Animated.View
-      style={[
-        {
-          position: 'absolute',
-          backgroundColor: 'red',
-          alignItems: 'center',
-          left: 0,
-          width: layout?.width ?? 0,
-          top: (layout?.height ?? -999) - 100,
-        },
-        animatedStyle,
-      ]}
-      onLayout={e => console.log('scrollindicatorlayout', e.nativeEvent.layout)}
-    >
-      <Text>{value}</Text>
-    </Animated.View>
   );
 };

--- a/src/components/playlist/SongList/SongList.tsx
+++ b/src/components/playlist/SongList/SongList.tsx
@@ -75,6 +75,13 @@ export default ({
     playlistRef,
   } = usedPlaylist;
 
+  const onContentHeightCHange = (h: number) => {
+    const contentH = h - scrollViewHeight.value;
+    scrollPosition.value =
+      (scrollPosition.value * contentHeight.value) / contentH;
+    contentHeight.value = contentH;
+  };
+
   const scrollBarOnScroll = (p: NativeScrollEvent) => {
     const contentH = Math.max(
       1,
@@ -209,6 +216,7 @@ export default ({
     <GestureDetector gesture={composedGesture}>
       <>
         <AnimatedFlashList
+          onContentSizeChange={onContentHeightCHange}
           onLayout={e => setFlashlistLayout(e.nativeEvent.layout)}
           renderScrollComponent={ScrollView}
           overrideProps={{

--- a/src/components/playlist/SongList/SongList.tsx
+++ b/src/components/playlist/SongList/SongList.tsx
@@ -185,6 +185,8 @@ export default ({
     Gesture.Simultaneous(pullUpRefreshGesture, nativeGesture),
   );
 
+  const gestureRef = React.useRef(pullUpRefreshGesture);
+
   useEffect(() => {
     layoutY.current = [];
   }, [rows]);
@@ -194,7 +196,7 @@ export default ({
       <AnimatedFlashList
         renderScrollComponent={ScrollView}
         overrideProps={{
-          simultaneousHandlers: composedGesture,
+          simultaneousHandlers: gestureRef,
         }}
         ref={playlistRef}
         data={rows}

--- a/src/components/playlist/SongList/SongList.tsx
+++ b/src/components/playlist/SongList/SongList.tsx
@@ -15,6 +15,7 @@ import {
   GestureDetector,
   ScrollView,
   RefreshControl,
+  PanGesture,
 } from 'react-native-gesture-handler';
 
 import SongInfo from './SongInfo';
@@ -173,7 +174,10 @@ export default ({
   const pullUpActivated = useSharedValue(0);
   const pullUpDistance = useSharedValue(0);
 
+  const gestureRef = React.useRef<PanGesture>(undefined);
+
   const pullUpRefreshGesture = Gesture.Pan()
+    .withRef(gestureRef)
     .onStart(e => {
       // if flashlist is at the very bottom, set pullupAct to 1
       // HACK: how to resolve js precision issue?
@@ -202,8 +206,6 @@ export default ({
     .onFinalize(() => {
       if (pullUpActivated.value > 0) pullUpActivated.value = 0;
     });
-
-  const gestureRef = React.useRef(pullUpRefreshGesture);
 
   const composedGesture = Gesture.Exclusive(
     scrollDragGesture,

--- a/src/components/playlist/SongList/SongList.tsx
+++ b/src/components/playlist/SongList/SongList.tsx
@@ -187,18 +187,20 @@ export default ({
     })
     .onChange(e => {
       if (pullUpActivated.value !== 1) return;
-      if (e.translationY > 0) return (pullUpActivated.value = 0);
+      if (e.translationY > 0) return (pullUpActivated.value = -1);
       pullUpDistance.value = e.translationY;
     })
     .onEnd(() => {
       if (pullUpActivated.value !== 1) return;
-      if (pullUpDistance.value < -100) {
+      if (pullUpDistance.value < -200) {
         runOnJS(refreshPlaylist)(true);
+      } else {
+        pullUpActivated.value = -1;
+        pullUpDistance.value = withTiming(0, { duration: 400 });
       }
     })
     .onFinalize(() => {
-      pullUpActivated.value = 0;
-      pullUpDistance.value = withTiming(0, { duration: 400 });
+      if (pullUpActivated.value > 0) pullUpActivated.value = 0;
     });
 
   const gestureRef = React.useRef(pullUpRefreshGesture);
@@ -257,6 +259,7 @@ export default ({
           onScroll={scrollHandler}
         />
         <RefreshIndicator
+          pullUpActivated={pullUpActivated}
           pullUpDistance={pullUpDistance}
           layout={flashlistLayout}
         />

--- a/src/components/playlist/usePlaylistRN.ts
+++ b/src/components/playlist/usePlaylistRN.ts
@@ -71,7 +71,7 @@ export default (playlist: NoxMedia.Playlist): UsePlaylistRN => {
   const { playFromPlaylist } = usePlayback();
   const { performFade } = useTPControls();
 
-  const refreshPlaylist = () => {
+  const refreshPlaylist = (addToEnd = false) => {
     progressEmitter(100);
     activateKeepAwakeAsync();
     return setSnack({
@@ -80,7 +80,7 @@ export default (playlist: NoxMedia.Playlist): UsePlaylistRN => {
         success: t('PlaylistOperations.updated', { playlist }),
         fail: '[refreshPlaylist] failed',
       },
-      processFunction: rssUpdate,
+      processFunction: () => rssUpdate(undefined, addToEnd),
       callback: () => {
         progressEmitter(0);
         deactivateKeepAwake();
@@ -240,7 +240,7 @@ export default (playlist: NoxMedia.Playlist): UsePlaylistRN => {
 };
 
 export interface UsePlaylistRN extends UsePlaylist {
-  refreshPlaylist: () => Promise<void>;
+  refreshPlaylist: (addToEnd?: boolean) => Promise<void>;
   cachedSongs: string[];
   setCachedSongs: (val: string[]) => void;
   handleSearch: (searchedVal: string) => void;

--- a/src/hooks/usePlaylist.ts
+++ b/src/hooks/usePlaylist.ts
@@ -24,6 +24,7 @@ export interface UsePlaylist {
   handleSearch: (searchedVal: string) => void;
   rssUpdate: (
     subscribeUrls?: string[],
+    addToEnd?: boolean,
   ) => Promise<NoxMedia.Playlist | undefined>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   searchBarRef: React.MutableRefObject<any>;
@@ -78,10 +79,10 @@ const usePlaylist = (playlist: NoxMedia.Playlist): UsePlaylist => {
     setRows(reParseSearch({ searchStr: searchedVal, rows: playlist.songList }));
   };
 
-  const rssUpdate = async (subscribeUrls?: string[]) => {
+  const rssUpdate = async (subscribeUrls?: string[], addToEnd = false) => {
     setRefreshing(true);
     try {
-      const result = await playlistCRUD.rssUpdate(subscribeUrls);
+      const result = await playlistCRUD.rssUpdate({ subscribeUrls, addToEnd });
       setRefreshing(false);
       return result;
     } catch (e) {

--- a/src/hooks/usePlaylistCRUD.ts
+++ b/src/hooks/usePlaylistCRUD.ts
@@ -10,6 +10,12 @@ import { sortPlaylist as _sortPlaylist } from '../utils/playlistOperations';
 import { SortOptions } from '../enums/Playlist';
 import { resolveUrl } from '@utils/SongOperations';
 
+export interface IRSSUpdate {
+  subscribeUrls?: string[];
+  playlist?: NoxMedia.Playlist | Promise<NoxMedia.Playlist>;
+  addToEnd?: boolean;
+}
+
 const usePlaylistCRUD = (mPlaylist?: NoxMedia.Playlist) => {
   const currentPlaylist = useNoxSetting(state => state.currentPlayingList);
   const currentPlayingId = useNoxSetting(state => state.currentPlayingId);
@@ -225,15 +231,17 @@ const usePlaylistCRUD = (mPlaylist?: NoxMedia.Playlist) => {
       .map(v => _getPlaylist(v))
       .forEach(playlist => removeSongs(songs, banBVID, playlist));
 
-  const rssUpdate = async (
-    subscribeUrls?: string[],
-    playlist: NoxMedia.Playlist | Promise<NoxMedia.Playlist> = getPlaylist(),
-  ) =>
+  const rssUpdate = async ({
+    subscribeUrls,
+    playlist = getPlaylist(),
+    addToEnd = false,
+  }: IRSSUpdate) =>
     updateSubscribeFavList({
       playlist: await playlist,
       subscribeUrls,
       progressEmitter,
       updatePlaylist,
+      addToEnd,
     });
 
   const playlistRemoveBiliShazamed = async (

--- a/src/utils/BiliSubscribe.ts
+++ b/src/utils/BiliSubscribe.ts
@@ -14,6 +14,7 @@ interface Props {
   progressEmitter?: NoxUtils.ProgressEmitter;
   overwriteOnRefresh?: () => boolean;
   callback?: (newPlaylist: NoxMedia.Playlist) => void;
+  addToEnd?: boolean;
 }
 export const updateSubscribeFavList = async ({
   playlist,
@@ -23,6 +24,7 @@ export const updateSubscribeFavList = async ({
   overwriteOnRefresh = () =>
     playlist.newSongOverwrite || playlist.title.includes('live'),
   callback = () => undefined,
+  addToEnd = false,
 }: Props): Promise<NoxMedia.Playlist | undefined> => {
   let newPlaylist = { ...playlist, lastSubscribed: new Date().getTime() };
   if ([PlaylistTypes.Favorite].includes(playlist.type)) {
@@ -36,7 +38,9 @@ export const updateSubscribeFavList = async ({
       return;
     }
     newPlaylist = { ...newPlaylist, ...(await playlist.refresh(newPlaylist)) };
-    newPlaylist.songList = newPlaylist.songList.concat(playlist.songList);
+    newPlaylist.songList = addToEnd
+      ? playlist.songList.concat(newPlaylist.songList)
+      : newPlaylist.songList.concat(playlist.songList);
   } else {
     subscribeUrls = subscribeUrls ?? playlist.subscribeUrl;
     if (subscribeUrls.length === 0 || subscribeUrls[0].length === 0) {


### PR DESCRIPTION
adds a pull up to refresh functionality for search playlists; songs will be added to the bottom of the playlist instead of top. 

https://blog.cloudboost.io/building-a-custom-refresh-animation-in-react-native-using-reanimated-9b64212a0366 but in reverse