### PR TITLE
fix: #1051

### DIFF
--- a/src/components/setting/helpers/RenderSetting.tsx
+++ b/src/components/setting/helpers/RenderSetting.tsx
@@ -9,15 +9,21 @@ interface Props {
   delayedLoading?: boolean;
 }
 
-export const RenderSetting = ({ item, delayedLoading }: Props) => {
-  switch (item.settingType) {
-    default:
-      return (
-        <BooleanSetting
-          {...item}
-          delayedLoading={delayedLoading}
-          key={uuidv4()}
-        />
-      );
-  }
-};
+export const RenderSetting = React.memo(
+  ({ item, delayedLoading }: Props) => {
+    switch (item.settingType) {
+      default:
+        return (
+          <BooleanSetting
+            {...item}
+            delayedLoading={delayedLoading}
+            key={uuidv4()}
+          />
+        );
+    }
+  },
+  (p, r) => {
+    console.log('memo', p, r);
+    return true;
+  },
+);

--- a/src/components/setting/helpers/RenderSetting.tsx
+++ b/src/components/setting/helpers/RenderSetting.tsx
@@ -9,21 +9,15 @@ interface Props {
   delayedLoading?: boolean;
 }
 
-export const RenderSetting = React.memo(
-  ({ item, delayedLoading }: Props) => {
-    switch (item.settingType) {
-      default:
-        return (
-          <BooleanSetting
-            {...item}
-            delayedLoading={delayedLoading}
-            key={uuidv4()}
-          />
-        );
-    }
-  },
-  (p, r) => {
-    console.log('memo', p, r);
-    return true;
-  },
-);
+export const RenderSetting = React.memo(({ item, delayedLoading }: Props) => {
+  switch (item.settingType) {
+    default:
+      return (
+        <BooleanSetting
+          {...item}
+          delayedLoading={delayedLoading}
+          key={uuidv4()}
+        />
+      );
+  }
+});


### PR DESCRIPTION
closes #1051 

the issue is setSelect triggers a rerender as the parent component's select state changed; this triggers rerenders all throughout the children components. and since all booleanSettings now have a 1ms delay rerender useEffect, it now flickers as they rerender bc they all are rerendering again. the solution is to memo RenderSetting/BooleanSetting