### PR TITLE
fix: crossfade

### DIFF
--- a/src/components/player/controls/usePlayerControls.ts
+++ b/src/components/player/controls/usePlayerControls.ts
@@ -28,8 +28,8 @@ export default () => {
   const { performSkipToNext, performSkipToPrevious, prepareSkipToNext } =
     useTPControls();
 
-  const [skipARepeat, setSkipARepeat] = React.useState(false);
-
+  const skipARepeat = useNoxSetting(state => state.skipARepeat);
+  const setSkipARepeat = useNoxSetting(state => state.setSkipARepeat);
   const abRepeat = useNoxSetting(state => state.abRepeat);
   const setABRepeat = useNoxSetting(state => state.setABRepeat);
   const bRepeatDuration = useNoxSetting(state => state.bRepeatDuration);

--- a/src/components/player/controls/usePlayerControls.ts
+++ b/src/components/player/controls/usePlayerControls.ts
@@ -101,6 +101,7 @@ export default () => {
             ? newABRepeat[0] * nextSong.duration
             : newABRepeat[2];
         setSkipARepeat(true);
+        logger.debug(`[crossfade] priming the fading player to ${arepeat}...`);
       }
       await TrackPlayer.crossFadePrepare(false, Number(arepeat));
       return;

--- a/src/components/player/controls/usePlayerControls.ts
+++ b/src/components/player/controls/usePlayerControls.ts
@@ -102,7 +102,7 @@ export default () => {
             : newABRepeat[2];
         setSkipARepeat(true);
       }
-      await TrackPlayer.crossFadePrepare(false, arepeat);
+      await TrackPlayer.crossFadePrepare(false, Number(arepeat));
       return;
     }
 

--- a/src/stores/useAPMPlayback.ts
+++ b/src/stores/useAPMPlayback.ts
@@ -10,6 +10,8 @@ export interface APMPlaybackStore {
 
   abRepeat: [number, number, number?, number?];
   setABRepeat: (val: [number, number, number?, number?]) => void;
+  skipARepeat: boolean;
+  setSkipARepeat: (val: boolean) => void;
   bRepeatDuration: number;
   setBRepeatDuration: (val: number) => void;
   crossfadingId: string;
@@ -30,6 +32,8 @@ const store: StateCreator<
 
   abRepeat: [0, 1],
   setABRepeat: val => set({ abRepeat: val }),
+  skipARepeat: false,
+  setSkipARepeat: val => set({ skipARepeat: val }),
   bRepeatDuration: 9999,
   setBRepeatDuration: val => set({ bRepeatDuration: val }),
   crossfadingId: '',


### PR DESCRIPTION
per sentry report, crossfadePrepare was called with arepeat as a string not number. but why?
newABRepeat[2] gotta be not a number