### PR TITLE
chore: migrate to RNGH pressables

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -14,21 +14,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
+      # probably only needed when RN has to be compiled from source
+      # - name: Free Disk Space (Ubuntu)
+      #   uses: jlumbroso/free-disk-space@main
+      #   with:
+      #     # this might remove tools that are actually needed,
+      #     # if set to "true" but frees about 6 GB
+      #     tool-cache: false
 
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: false
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: false
+      #     # all of these default to true, but feel free to set to
+      #     # "false" if necessary for your workflow
+      #     android: false
+      #     dotnet: true
+      #     haskell: true
+      #     large-packages: true
+      #     docker-images: true
+      #     swap-storage: false
 
       - name: python version_bump.py
         run: |
@@ -131,22 +132,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: false
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: false
 
       - name: python version_bump.py
         run: |

--- a/.github/workflows/android-weekly.yml
+++ b/.github/workflows/android-weekly.yml
@@ -52,22 +52,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: false
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: false
-
       - name: Get branch name
         run: |
           # Short name for current branch. For PRs, use target branch (base ref)

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -15,22 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: false
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: false
-
       - name: Get branch name
         run: |
           # Short name for current branch. For PRs, use target branch (base ref)

--- a/.github/workflows/play-release.yml
+++ b/.github/workflows/play-release.yml
@@ -11,22 +11,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: false
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: false
-
       - name: python version_bump.py
         run: |
           python ./scripts/version_bump.py

--- a/.github/workflows/play-review.yml
+++ b/.github/workflows/play-review.yml
@@ -11,22 +11,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: false
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: false
-
       - name: python version_bump.py
         run: |
           python ./scripts/version_bump.py

--- a/src/components/commonui/RNGHPaperWrapper.tsx
+++ b/src/components/commonui/RNGHPaperWrapper.tsx
@@ -1,0 +1,23 @@
+import { Pressable } from 'react-native-gesture-handler';
+import { IconButton as PaperIconButton } from 'react-native-paper';
+import { Props as PaperIconButtonProps } from 'react-native-paper/lib/typescript/components/IconButton/IconButton';
+
+// wraps rnpaper's icon button to use RNGH's pressable. solves button not working inside
+// of a RNGH pressable.
+
+interface IconButtonProps extends PaperIconButtonProps {
+  hideRipple?: boolean;
+}
+
+export const IconButton = (p: IconButtonProps) => {
+  return (
+    // TODO: write a wrapper to translate gesture event to native event
+    // @ts-expect-error
+    <Pressable onPress={p.disabled ? undefined : p.onPress}>
+      <PaperIconButton
+        {...p}
+        onPress={p.hideRipple || p.onPress === undefined ? undefined : () => {}}
+      />
+    </Pressable>
+  );
+};

--- a/src/components/commonui/ScaledText.tsx
+++ b/src/components/commonui/ScaledText.tsx
@@ -12,6 +12,7 @@ import {
   ListItemProps,
 } from 'react-native-paper';
 import _MarqueeText, { TextTickerProps } from 'react-native-text-ticker';
+import { RectButton } from 'react-native-gesture-handler';
 
 import { typescale } from './PaperTextVariant';
 import { useNoxSetting } from '@stores/useApp';
@@ -93,11 +94,16 @@ export const PaperListItem = (p: PaperListItemProps) => {
   });
 
   return (
-    <List.Item
-      {...p}
-      titleStyle={scaledTitleStyle}
-      descriptionStyle={scaledDescStyle}
-    />
+    // TODO: use a wrapper here
+    // @ts-expect-error
+    <RectButton onPress={p.onPress}>
+      <List.Item
+        {...p}
+        onPress={undefined}
+        titleStyle={scaledTitleStyle}
+        descriptionStyle={scaledDescStyle}
+      />
+    </RectButton>
   );
 };
 

--- a/src/components/commonui/bottomsheet/SheetIconEntry.tsx
+++ b/src/components/commonui/bottomsheet/SheetIconEntry.tsx
@@ -1,5 +1,6 @@
 import { StyleSheet, View } from 'react-native';
-import { IconButton, TouchableRipple } from 'react-native-paper';
+import { IconButton } from 'react-native-paper';
+import { RectButton } from 'react-native-gesture-handler';
 
 import { Props } from './SheetIconButton';
 import { PaperText as Text } from '@components/commonui/ScaledText';
@@ -7,12 +8,12 @@ import { PaperText as Text } from '@components/commonui/ScaledText';
 export default ({ icon, text, onPress, disabled, children }: Props) => {
   return (
     <View>
-      <TouchableRipple onPress={onPress} disabled={disabled}>
+      <RectButton onPress={disabled ? undefined : onPress}>
         <View style={styles.view}>
           <IconButton icon={icon} size={32} disabled={disabled} />
           <Text style={disabled && styles.disabledText}> {text} </Text>
         </View>
-      </TouchableRipple>
+      </RectButton>
       {children}
     </View>
   );

--- a/src/components/playlist/SongList/SongInfo.tsx
+++ b/src/components/playlist/SongList/SongInfo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox, IconButton, TouchableRipple } from 'react-native-paper';
+import { Checkbox, IconButton } from 'react-native-paper';
 import { View, StyleSheet } from 'react-native';
 import {
   DerivedValue,
@@ -10,6 +10,7 @@ import inRange from 'lodash/inRange';
 import throttle from 'lodash/throttle';
 import { TrueSheet } from '@lodev09/react-native-true-sheet';
 import { scheduleOnRN } from 'react-native-worklets';
+import { RectButton } from 'react-native-gesture-handler';
 
 import { PaperText as Text } from '@components/commonui/ScaledText';
 import { useNoxSetting } from '@stores/useApp';
@@ -118,7 +119,7 @@ const SongInfo = ({
         },
       ]}
     >
-      <TouchableRipple
+      <RectButton
         onLongPress={checking ? toggleCheck : onLongPress}
         onPress={checking ? toggleCheck : () => playSong(item)}
       >
@@ -163,7 +164,7 @@ const SongInfo = ({
             />
           </View>
         </View>
-      </TouchableRipple>
+      </RectButton>
     </View>
   );
 };

--- a/src/components/playlist/SongList/SongInfo.tsx
+++ b/src/components/playlist/SongList/SongInfo.tsx
@@ -10,7 +10,7 @@ import inRange from 'lodash/inRange';
 import throttle from 'lodash/throttle';
 import { TrueSheet } from '@lodev09/react-native-true-sheet';
 import { scheduleOnRN } from 'react-native-worklets';
-import { RectButton } from 'react-native-gesture-handler';
+import { Pressable, RectButton } from 'react-native-gesture-handler';
 
 import { PaperText as Text } from '@components/commonui/ScaledText';
 import { useNoxSetting } from '@stores/useApp';
@@ -154,14 +154,14 @@ const SongInfo = ({
             <Text variant="titleSmall" style={styles.time}>
               {seconds2MMSS(item.duration)}
             </Text>
-            <IconButton
-              icon="dots-vertical"
+            <Pressable
               onPress={() => {
                 setSongMenuSongIndexes([getSongIndex()]);
                 TrueSheet.present(NoxSheetRoutes.SongsMenuInListSheet);
               }}
-              size={20}
-            />
+            >
+              <IconButton icon="dots-vertical" size={20} />
+            </Pressable>
           </View>
         </View>
       </RectButton>

--- a/src/components/playlist/SongList/SongInfo.tsx
+++ b/src/components/playlist/SongList/SongInfo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox, IconButton } from 'react-native-paper';
+import { Checkbox } from 'react-native-paper';
 import { View, StyleSheet } from 'react-native';
 import {
   DerivedValue,
@@ -20,6 +20,7 @@ import NoxCache from '@utils/Cache';
 import { UsePlaylistRN } from '../usePlaylistRN';
 import { getArtistName } from '@objects/Song';
 import { NoxSheetRoutes } from '@enums/Routes';
+import { IconButton } from '@components/commonui/RNGHPaperWrapper';
 
 interface Props {
   item: NoxMedia.Song;
@@ -154,14 +155,14 @@ const SongInfo = ({
             <Text variant="titleSmall" style={styles.time}>
               {seconds2MMSS(item.duration)}
             </Text>
-            <Pressable
+            <IconButton
+              icon="dots-vertical"
+              size={20}
               onPress={() => {
                 setSongMenuSongIndexes([getSongIndex()]);
                 TrueSheet.present(NoxSheetRoutes.SongsMenuInListSheet);
               }}
-            >
-              <IconButton icon="dots-vertical" size={20} onPress={() => {}} />
-            </Pressable>
+            />
           </View>
         </View>
       </RectButton>

--- a/src/components/playlist/SongList/SongInfo.tsx
+++ b/src/components/playlist/SongList/SongInfo.tsx
@@ -107,19 +107,17 @@ const SongInfo = ({
   return (
     <View
       testID={testID}
-      style={[
-        styles.container,
-        {
-          backgroundColor: currentPlaying
-            ? 'rgba(103, 80, 164, 0.35)'
-            : 'transparent',
-          opacity: isItemSolid(item, networkCellular, playerSetting.dataSaver)
-            ? undefined
-            : 0.5,
-        },
-      ]}
+      style={{
+        backgroundColor: currentPlaying
+          ? 'rgba(103, 80, 164, 0.35)'
+          : 'transparent',
+        opacity: isItemSolid(item, networkCellular, playerSetting.dataSaver)
+          ? undefined
+          : 0.5,
+      }}
     >
       <RectButton
+        style={styles.container}
         onLongPress={checking ? toggleCheck : onLongPress}
         onPress={checking ? toggleCheck : () => playSong(item)}
       >
@@ -128,10 +126,12 @@ const SongInfo = ({
             <View style={styles.row}>
               {checking && (
                 <View style={styles.checkBox}>
-                  <Checkbox
-                    status={checked ? 'checked' : 'unchecked'}
-                    onPress={toggleCheck}
-                  />
+                  <Pressable onPress={toggleCheck}>
+                    <Checkbox
+                      status={checked ? 'checked' : 'unchecked'}
+                      onPress={() => {}}
+                    />
+                  </Pressable>
                 </View>
               )}
               <View style={styles.songTitle}>
@@ -160,7 +160,7 @@ const SongInfo = ({
                 TrueSheet.present(NoxSheetRoutes.SongsMenuInListSheet);
               }}
             >
-              <IconButton icon="dots-vertical" size={20} />
+              <IconButton icon="dots-vertical" size={20} onPress={() => {}} />
             </Pressable>
           </View>
         </View>

--- a/src/components/playlists/PlaylistItem.tsx
+++ b/src/components/playlists/PlaylistItem.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode } from 'react';
-import { IconButton } from 'react-native-paper';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { useNoxSetting } from '@stores/useApp';
 import { PaperText as Text } from '@components/commonui/ScaledText';
+import { IconButton } from '../commonui/RNGHPaperWrapper';
 
 const DefaultIcon = (
   item: NoxMedia.Playlist,

--- a/src/components/playlists/Playlists.tsx
+++ b/src/components/playlists/Playlists.tsx
@@ -6,6 +6,7 @@ import { useDrawerProgress } from '@react-navigation/drawer';
 import { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types';
 import { scheduleOnRN } from 'react-native-worklets';
 import { useAnimatedReaction } from 'react-native-reanimated';
+import { RectButton } from 'react-native-gesture-handler';
 
 import { useNoxSetting } from '@stores/useApp';
 import { NoxRoutes } from '@enums/Routes';
@@ -101,7 +102,7 @@ export default ({ navigation }: { navigation: DrawerNavigationHelpers }) => {
   ) => {
     const playlist = playlists[item];
     return (
-      <TouchableRipple
+      <RectButton
         key={index}
         onPress={() => goToPlaylist(item)}
         onLongPress={beginDrag}
@@ -126,7 +127,7 @@ export default ({ navigation }: { navigation: DrawerNavigationHelpers }) => {
               : undefined
           }
         />
-      </TouchableRipple>
+      </RectButton>
     );
   };
 

--- a/src/components/playlists/Playlists.tsx
+++ b/src/components/playlists/Playlists.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { IconButton, TouchableRipple } from 'react-native-paper';
-import { Pressable, View, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import FlashDragList from 'react-native-flashdrag-list';
 import { useDrawerProgress } from '@react-navigation/drawer';
 import { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types';
@@ -29,14 +29,13 @@ const SearchPlaylistAsNewButton = ({
 }: NewButtonProps) => {
   const playerStyle = useNoxSetting(state => state.playerStyle);
   return (
-    <Pressable onPress={() => setNewPlaylistDialogOpen(true)}>
-      <IconButton
-        testID="search-playlist-as-new-playlist-button"
-        icon="new-box"
-        size={25}
-        iconColor={playerStyle.colors.primary}
-      />
-    </Pressable>
+    <IconButton
+      testID="search-playlist-as-new-playlist-button"
+      icon="new-box"
+      size={25}
+      iconColor={playerStyle.colors.primary}
+      onPress={() => setNewPlaylistDialogOpen(true)}
+    />
   );
 };
 

--- a/src/components/playlists/View.tsx
+++ b/src/components/playlists/View.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect } from 'react';
-import { IconButton, Divider, TouchableRipple } from 'react-native-paper';
+import { IconButton, Divider } from 'react-native-paper';
 import { View, ImageBackground, StyleSheet, Linking } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { RectButton } from 'react-native-gesture-handler';
 
 import { PaperText as Text } from '@components/commonui/ScaledText';
 import { useNoxSetting } from '@stores/useApp';
@@ -36,7 +37,7 @@ const RenderDrawerItem = ({
   const playerStyle = useNoxSetting(state => state.playerStyle);
 
   return (
-    <TouchableRipple
+    <RectButton
       onPress={() =>
         noxNavigation.navigate({
           route: view,
@@ -54,7 +55,7 @@ const RenderDrawerItem = ({
           <Text variant="titleLarge">{t(text)}</Text>
         </View>
       </View>
-    </TouchableRipple>
+    </RectButton>
   );
 };
 

--- a/src/components/setting/alist/View.tsx
+++ b/src/components/setting/alist/View.tsx
@@ -1,6 +1,7 @@
 import { View, FlatList } from 'react-native';
 import { useEffect, useState } from 'react';
-import { IconButton, TouchableRipple } from 'react-native-paper';
+import { IconButton } from 'react-native-paper';
+import { RectButton } from 'react-native-gesture-handler';
 
 import { PaperText as Text } from '@components/commonui/ScaledText';
 import {
@@ -68,7 +69,7 @@ export default () => {
         extraData={rerender}
         renderItem={({ item, index }) => (
           <View style={styles.rowView}>
-            <TouchableRipple
+            <RectButton
               style={[styles.contentContainer, styles.alignMiddle]}
               onPress={() => {
                 setCurrentCred(credList[index]);
@@ -76,7 +77,7 @@ export default () => {
               }}
             >
               <Text variant="displaySmall">{item[0]}</Text>
-            </TouchableRipple>
+            </RectButton>
             <View style={styles.alignMiddle}>
               <IconButton
                 icon={'delete'}

--- a/src/components/setting/appearances/SkinSettings.tsx
+++ b/src/components/setting/appearances/SkinSettings.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Image } from 'expo-image';
 import { View, SafeAreaView, LayoutAnimation } from 'react-native';
-import { IconButton, TouchableRipple } from 'react-native-paper';
 import { FlashList, FlashListRef } from '@shopify/flash-list';
+import { RectButton } from 'react-native-gesture-handler';
 
 import { PaperText as Text } from '@components/commonui/ScaledText';
 import SkinSearchbar from './SkinSearchbar';
@@ -20,6 +20,7 @@ import {
 } from '@components/style';
 import { setDarkTheme } from '@utils/RNUtils';
 import { saveColorScheme } from '@utils/ChromeStorageAPI';
+import { IconButton } from '@components/commonui/RNGHPaperWrapper';
 
 interface DisplayTheme extends NoxTheme.Style {
   builtin: boolean;
@@ -80,7 +81,7 @@ const SkinItem = ({
   };
 
   return (
-    <TouchableRipple onPress={selectTheme} onLongPress={onHold}>
+    <RectButton onPress={selectTheme} onLongPress={onHold}>
       <View
         style={[
           styles.skinItemContainer,
@@ -131,12 +132,12 @@ const SkinItem = ({
           <IconButton
             icon="trash-can"
             style={styles.deleteButton}
-            onPress={deleteTheme}
             disabled={skin.builtin}
+            onPress={deleteTheme}
           />
         </View>
       </View>
-    </TouchableRipple>
+    </RectButton>
   );
 };
 

--- a/src/components/setting/helpers/BooleanSetting.tsx
+++ b/src/components/setting/helpers/BooleanSetting.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { View, StyleSheet } from 'react-native';
-import { Switch, TouchableRipple, Checkbox } from 'react-native-paper';
+import { Switch, Checkbox } from 'react-native-paper';
+import { Pressable, RectButton } from 'react-native-gesture-handler';
 
 import { NativeText as Text } from '@components/commonui/ScaledText';
 import { useNoxSetting } from '@stores/useApp';
@@ -42,7 +43,7 @@ const BooleanSetting = ({
   }, []);
 
   return (
-    <TouchableRipple onPress={onToggle} style={styles.touchableRipple}>
+    <RectButton onPress={onToggle} style={styles.touchableRipple}>
       <View style={styles.settingContainer}>
         <View style={styles.settingTextContainer}>
           <Text
@@ -63,22 +64,24 @@ const BooleanSetting = ({
           </Text>
         </View>
         <View style={styles.switchContainer}>
-          {(!delayedLoading || loaded) &&
-            // delayedComponent doesnt work here, i dunno
-            (checkbox ? (
-              <Checkbox
-                status={playerSetting[settingName] ? 'checked' : 'unchecked'}
-                onPress={onToggle}
-              />
-            ) : (
-              <Switch
-                value={playerSetting[settingName]}
-                onValueChange={onToggle}
-              />
-            ))}
+          <Pressable onPress={onToggle}>
+            {(!delayedLoading || loaded) &&
+              // delayedComponent doesnt work here, i dunno
+              (checkbox ? (
+                <Checkbox
+                  status={playerSetting[settingName] ? 'checked' : 'unchecked'}
+                  onPress={() => void 0}
+                />
+              ) : (
+                <Switch
+                  value={playerSetting[settingName]}
+                  onValueChange={() => void 0}
+                />
+              ))}
+          </Pressable>
         </View>
       </View>
-    </TouchableRipple>
+    </RectButton>
   );
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked touch/press handling to use gesture-based buttons for sheet entries, song items, and playlist creation, improving responsiveness and consistency.
  * Disabled states and long-press behavior remain respected; playlist creation now triggers from the icon itself for a narrower touch target.

* **Chores**
  * Removed the prior free-disk-space cleanup step from several CI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->