### PR TITLE
fix: duplicated skip

### DIFF
--- a/src/hooks/useTPControls.ts
+++ b/src/hooks/useTPControls.ts
@@ -130,15 +130,7 @@ export const performSkipToNext = (
       //await TrackPlayer.skipToNext();
       // WHY?
       const nextIndex = ((await TrackPlayer.getActiveTrackIndex()) ?? 0) + 1;
-      let maxQueueLen = (await TrackPlayer.getQueue()).length - 1;
-      if (nextIndex > maxQueueLen) {
-        logger.error(
-          '[skipToNext] failed to skip to next song. attempt to retry preparePromise',
-        );
-        await preparePromise();
-        maxQueueLen = (await TrackPlayer.getQueue()).length - 1;
-        logger.warn(`[skipToNext] current status: ${nextIndex}/${maxQueueLen}`);
-      }
+      const maxQueueLen = (await TrackPlayer.getQueue()).length - 1;
       // HACK: log when nextIndex > maxQueueLen here
       await TrackPlayer.skip(Math.min(nextIndex, maxQueueLen));
       TPPlay();

--- a/src/hooks/useTrackMV.ts
+++ b/src/hooks/useTrackMV.ts
@@ -39,13 +39,14 @@ export default function useTackMV(videoRef: RefObject<VideoRef | null>) {
   };
 
   useLazyEffect(() => {
-    execWhenTrue({
-      loopCheck: async () => videoRef.current !== null,
-      executeFn: primeVideoPosition,
-      funcName: 'primeVideoPosition',
-      loopGuard: 5,
-      wait: 300,
-    });
+    parsedMV &&
+      execWhenTrue({
+        loopCheck: async () => videoRef.current !== null,
+        executeFn: primeVideoPosition,
+        funcName: 'primeVideoPosition',
+        loopGuard: 5,
+        wait: 300,
+      });
   }, [RNTPPlay, RNTPSeek]);
 
   useEffect(() => {


### PR DESCRIPTION
push to test and see if this needs to  be restored sepcifically on crossfade. right now this breaks on normal playback
closes #1130 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified track skipping logic for improved reliability.
  * Added safety checks in track data handling to prevent unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->