### PR TITLE
fix: disable bili r128gain by default

### DIFF
--- a/src/objects/Storage.ts
+++ b/src/objects/Storage.ts
@@ -54,7 +54,7 @@ const _DefaultSetting: NoxStorage.PlayerSettingDict = {
   artworkRes: 0,
   artworkCarousel: false,
   pausePlaybackOnMute: false,
-  noBiliR128Gain: false,
+  noBiliR128Gain: true,
   smartShuffle: true,
   lyricTap: true,
   fontScale: 1,


### PR DESCRIPTION
implementaion wasnt clear to begin with. disabling it by default
closes #1175 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default audio processing setting to improve handling of loudness normalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->