### PR TITLE
fix: bilisearch cookies

### DIFF
--- a/__tests__/mediafetch/biliSearch.test.ts
+++ b/__tests__/mediafetch/biliSearch.test.ts
@@ -1,5 +1,5 @@
 import fetcher from '../../src/utils/mediafetch/bilisearch';
-test('biliseries', async () => {
+test('bilisearch', async () => {
   const content = await fetcher.regexFetch({ url: 'wake', fastSearch: true });
   console.log(content);
   expect(content?.songList[0]?.id).not.toBeUndefined();

--- a/src/utils/mediafetch/bilisearch.ts
+++ b/src/utils/mediafetch/bilisearch.ts
@@ -72,7 +72,9 @@ export const fetchBiliSearchList = async (
       params: {
         method: 'GET',
         headers: {
-          cookie: await getCookie(cookiedSearch),
+          cookie: cookiedSearch
+            ? `SESSDATA=${await getBiliCookie(BILICOOKIES.SESSDATA)}`
+            : undefined,
         },
         referrer: 'https://www.bilibili.com',
         // HACK: setting to omit will use whatever cookie I set above.


### PR DESCRIPTION
does not need buvid3 anymore? is it wbi?
closes #1183 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication cookie handling for search requests to improve reliability.

* **Tests**
  * Corrected test naming for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->