### PR TITLE
fix: force HTTPS on alist resolved url

### DIFF
--- a/src/utils/mediafetch/alist.ts
+++ b/src/utils/mediafetch/alist.ts
@@ -105,7 +105,7 @@ const resolveURL = async (song: NoxMedia.Song) => {
           }),
         ),
         json = await res.json();
-      return { url: json.data.raw_url };
+      return { url: json.data.raw_url.replaceAll('http://', 'https://') };
     } catch {
       logger.error(`[alist] failed to resolve ${song.singerId}${song.bvid}`);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Media URLs are now resolved over HTTPS protocol for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->