### PR TITLE
feat: alist search param

### DIFF
--- a/src/utils/mediafetch/alist.ts
+++ b/src/utils/mediafetch/alist.ts
@@ -45,7 +45,9 @@ const fetchAlistMediaContent = async (
   fastSearch = true,
   result: NoxMedia.Song[] = [],
 ) => {
-  const { hostname, pathname } = new URL(url);
+  const { hostname, pathname, searchParams } = new URL(url);
+  const parsedSearchParams = Object.fromEntries(searchParams.entries());
+  const searchSubfolder = !fastSearch || parsedSearchParams.sub !== undefined;
   const paddedPath = pathname.endsWith('/') ? pathname : `${pathname}/`;
   const parsedPath = decodeURI(`https://1.t/${paddedPath}`).substring(12);
   const cred = await getCred(hostname);
@@ -73,10 +75,10 @@ const fetchAlistMediaContent = async (
   }
   for (const item of json.data.content) {
     if (item.is_dir) {
-      if (!fastSearch) {
+      if (searchSubfolder) {
         result = await fetchAlistMediaContent(
-          `${url}/${item.name}`,
-          fastSearch,
+          `${url.split('?')[0]}/${item.name}`,
+          searchSubfolder,
           result,
         );
       }


### PR DESCRIPTION
i dont really want to turn off fast bili search for alist subfolder so a url search param is the next best solution
closes #1220 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subfolder traversal logic and URL query parameter handling in search functionality for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->