### PR TITLE
chore: fix CICD

### DIFF
--- a/.github/composite-actions/android-runner-setup/action.yml
+++ b/.github/composite-actions/android-runner-setup/action.yml
@@ -4,21 +4,21 @@ description: RN new arch android build sometimes run out of space so it needs sp
 runs:
   using: 'composite'
   steps:
-    # - name: Free Disk Space (Ubuntu)
-    #   uses: jlumbroso/free-disk-space@main
-    #   with:
-    #     # this might remove tools that are actually needed,
-    #     # if set to "true" but frees about 6 GB
-    #     tool-cache: false
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
 
-    #     # all of these default to true, but feel free to set to
-    #     # "false" if necessary for your workflow
-    #     android: false
-    #     dotnet: true
-    #     haskell: true
-    #     large-packages: true
-    #     docker-images: true
-    #     swap-storage: false
+        # all of these default to true, but feel free to set to
+        # "false" if necessary for your workflow
+        android: false
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: false
 
     - name: set up JDK 18
       uses: actions/setup-java@v4


### PR DESCRIPTION
still runs out of space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD infrastructure for Android builds by enabling automated disk space cleanup and configuring resource management defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->