### PR TITLE
fix: disable expo-video keepScreenOn

### DIFF
--- a/src/components/background/MainBackground.tsx
+++ b/src/components/background/MainBackground.tsx
@@ -29,6 +29,7 @@ const MainBackground = () => {
     player.audioMixingMode = 'mixWithOthers';
     player.volume = 0;
     player.loop = true;
+    player.keepScreenOnWhilePlaying = false;
   });
   const { parsedMV: trackMV, primeVideoPosition } = useTrackMV(player);
 

--- a/src/components/background/VoicePlayer.tsx
+++ b/src/components/background/VoicePlayer.tsx
@@ -8,6 +8,7 @@ interface Props {
 export default function VoicePlayer({ uri }: Props) {
   const player = useVideoPlayer({ assetId: uri }, player => {
     player.audioMixingMode = 'mixWithOthers';
+    player.keepScreenOnWhilePlaying = false;
   });
 
   React.useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified screen behavior: the device screen will no longer remain active while video or audio content is playing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->