### PR TITLE
feat: expo-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "@material/material-color-utilities": "^0.4.0",
     "@react-native-community/eslint-config": "^3.2.0",
     "@tsconfig/react-native": "^3.0.9",
+    "@types/color": "^4.2.1",
     "@types/crypto-js": "^4.2.2",
     "@types/d3": "^7.4.3",
     "@types/he": "^1.2.3",

--- a/src/components/artist/View.tsx
+++ b/src/components/artist/View.tsx
@@ -14,7 +14,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
-import { IconButton, ActivityIndicator } from 'react-native-paper';
+import { IconButton } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -27,6 +27,7 @@ import { useNoxSetting } from '@stores/useApp';
 import { goToArtistExternalPage } from '@utils/artistfetch/fetch';
 import { styles, ItemSelectStyles } from '../style';
 import AutoUnmountNavView from '../commonui/AutoUnmountNavView';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 export default function ArtistView({
   navigation,

--- a/src/components/billing/View.tsx
+++ b/src/components/billing/View.tsx
@@ -1,6 +1,6 @@
 import { View, StyleSheet, Pressable } from 'react-native';
 import React, { useEffect, useState } from 'react';
-import { Button, ActivityIndicator } from 'react-native-paper';
+import { Button } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import { Image } from 'expo-image';
 import * as Clipboard from 'expo-clipboard';
@@ -11,6 +11,7 @@ import { styles } from '../style';
 // eslint-disable-next-line import/no-unresolved
 import { APPSTORE } from '@env';
 import getUser from '@utils/Bilibili/BiliUser';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 interface LoadingChildrenProps {
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/components/commonui/ActivityIndicator.android.tsx
+++ b/src/components/commonui/ActivityIndicator.android.tsx
@@ -1,5 +1,4 @@
 import { ActivityIndicator } from 'react-native-paper';
-import { Props } from 'react-native-paper/src/components/ActivityIndicator';
 import {
   Host,
   CircularProgressIndicator,
@@ -10,14 +9,11 @@ import { useNoxSetting } from '@stores/useApp';
 import { isAndroid } from '@utils/RNUtils';
 import { View } from 'react-native';
 
-interface MyProps extends Props {
-  wavy?: boolean;
-  trackColor?: string;
-}
-
 const MD3SizeToPaperSize = 40;
 
-export default (p: MyProps) => {
+export default function APMActivityIndicator(
+  p: NoxComponent.ActivityIndicatorProps,
+) {
   const playerSetting = useNoxSetting(state => state.playerSetting);
   const playerStyle = useNoxSetting(state => state.playerStyle);
   const MD3Indicator = p.wavy
@@ -35,7 +31,7 @@ export default (p: MyProps) => {
                 {
                   scale:
                     typeof p.size === 'number'
-                      ? (p.size ?? MD3SizeToPaperSize) / MD3SizeToPaperSize
+                      ? p.size / MD3SizeToPaperSize
                       : 1,
                 },
               ],
@@ -53,4 +49,4 @@ export default (p: MyProps) => {
     );
   }
   return <ActivityIndicator {...p} />;
-};
+}

--- a/src/components/commonui/ActivityIndicator.android.tsx
+++ b/src/components/commonui/ActivityIndicator.android.tsx
@@ -1,0 +1,56 @@
+import { ActivityIndicator } from 'react-native-paper';
+import { Props } from 'react-native-paper/src/components/ActivityIndicator';
+import {
+  Host,
+  CircularProgressIndicator,
+  CircularWavyProgressIndicator,
+} from '@expo/ui/jetpack-compose';
+
+import { useNoxSetting } from '@stores/useApp';
+import { isAndroid } from '@utils/RNUtils';
+import { View } from 'react-native';
+
+interface MyProps extends Props {
+  wavy?: boolean;
+  trackColor?: string;
+}
+
+const MD3SizeToPaperSize = 40;
+
+export default (p: MyProps) => {
+  const playerSetting = useNoxSetting(state => state.playerSetting);
+  const playerStyle = useNoxSetting(state => state.playerStyle);
+  const MD3Indicator = p.wavy
+    ? CircularWavyProgressIndicator
+    : CircularProgressIndicator;
+
+  if (playerSetting.md3slider && isAndroid) {
+    return (
+      <View style={[p.style, { justifyContent: 'center' }]}>
+        <Host
+          matchContents
+          style={[
+            {
+              transform: [
+                {
+                  scale:
+                    typeof p.size === 'number'
+                      ? (p.size ?? MD3SizeToPaperSize) / MD3SizeToPaperSize
+                      : 1,
+                },
+              ],
+              alignSelf: 'center',
+              marginHorizontal: 6 + 3,
+            },
+          ]}
+        >
+          <MD3Indicator
+            color={p.theme?.colors?.primary ?? playerStyle.colors.primary}
+            trackColor={p.trackColor}
+          />
+        </Host>
+      </View>
+    );
+  }
+  return <ActivityIndicator {...p} />;
+};

--- a/src/components/commonui/ActivityIndicator.tsx
+++ b/src/components/commonui/ActivityIndicator.tsx
@@ -1,0 +1,3 @@
+import { ActivityIndicator } from 'react-native-paper';
+
+export default ActivityIndicator;

--- a/src/components/commonui/ActivityIndicator.tsx
+++ b/src/components/commonui/ActivityIndicator.tsx
@@ -1,3 +1,7 @@
 import { ActivityIndicator } from 'react-native-paper';
 
-export default ActivityIndicator;
+export default function APMActivityIndicator(
+  p: NoxComponent.ActivityIndicatorProps,
+) {
+  return <ActivityIndicator {...p} />;
+}

--- a/src/components/commonui/DelayedComponent.tsx
+++ b/src/components/commonui/DelayedComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
-import { ActivityIndicator } from 'react-native-paper';
+
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 const DefaultSuspenseComponent = () => (
   <View style={{ alignContent: 'center', justifyContent: 'center', flex: 1 }}>

--- a/src/components/explore/Bilibili.tsx
+++ b/src/components/explore/Bilibili.tsx
@@ -6,7 +6,6 @@ import {
   StyleSheet,
   ViewStyle,
 } from 'react-native';
-import { ActivityIndicator } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 
 import { styles } from '@components/style';
@@ -15,6 +14,7 @@ import { BiliSongRow } from './SongRow';
 import useBiliExplore from '@stores/explore/bilibili';
 import { BiliMusicTid } from '@enums/MediaFetch';
 import { PaperText as Text } from '@components/commonui/ScaledText';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 interface Props extends NoxComponent.ScrollableProps {
   style?: ViewStyle;

--- a/src/components/explore/YTMChart.tsx
+++ b/src/components/explore/YTMChart.tsx
@@ -1,5 +1,4 @@
 import { View, ScrollView, RefreshControl } from 'react-native';
-import { ActivityIndicator } from 'react-native-paper';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -7,6 +6,7 @@ import { styles } from '@components/style';
 import useYTMChartExplore from '@stores/explore/ytmchart.muse';
 import { YTMixedContent } from './YTMusic';
 import { toMixedContent } from './Utils';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 export default function ExploreYTMChart({
   onScroll,

--- a/src/components/explore/YTMusic.tsx
+++ b/src/components/explore/YTMusic.tsx
@@ -1,5 +1,5 @@
 import { View, ScrollView } from 'react-native';
-import { ActivityIndicator, Button } from 'react-native-paper';
+import { Button } from 'react-native-paper';
 import React, { useEffect, useState } from 'react';
 import isArray from 'lodash/isArray';
 import {
@@ -21,6 +21,7 @@ import useYTMExplore, {
 } from '@stores/explore/ytmHome.muse';
 import { YTSongRow } from './SongRow';
 import { BiliSongsArrayTabCard } from './SongTab';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 interface ContentProps {
   content: MixedContent;

--- a/src/components/explore/YTMusic.ytbi.tsx
+++ b/src/components/explore/YTMusic.ytbi.tsx
@@ -1,5 +1,5 @@
 import { View, ScrollView } from 'react-native';
-import { ActivityIndicator, Button } from 'react-native-paper';
+import { Button } from 'react-native-paper';
 import React, { useEffect } from 'react';
 import isArray from 'lodash/isArray';
 import {
@@ -18,6 +18,7 @@ import useYTMExplore, {
 } from '@stores/explore/ytmHome.ytbi';
 import { YTSongRow } from './SongRow';
 import { BiliSongsArrayTabCard } from './SongTab';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 interface ContentProps {
   content: MusicCarouselShelf;

--- a/src/components/login/bilibili/BiliSelectFavButtton.tsx
+++ b/src/components/login/bilibili/BiliSelectFavButtton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ActivityIndicator } from 'react-native-paper';
+import { Button } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 
 import { getBiliFavlist, GetFavlistRes } from '@utils/Bilibili/bilifavOperate';
@@ -7,6 +7,7 @@ import GenericCheckDialog from '../../dialogs/GenericCheckDialog';
 import bilifavlistFetch from '@utils/mediafetch/bilifavlist';
 import { dummyPlaylist } from '@objects/Playlist';
 import usePlaylistBrowseTree from '@hooks/usePlaylistBrowseTree';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 export default function BiliSelectFavButton() {
   const { t } = useTranslation();

--- a/src/components/login/bilibili/Bilibili.tsx
+++ b/src/components/login/bilibili/Bilibili.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { View, StyleSheet, ScrollView } from 'react-native';
-import { Avatar, ActivityIndicator, Button } from 'react-native-paper';
+import { Avatar, Button } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import QRCode from 'react-native-qrcode-svg';
 import CookieManager from '@preeternal/react-native-cookie-manager';
@@ -14,6 +14,7 @@ import { BiliLogin } from './useBiliLoginApp';
 import useSnack from '@stores/useSnack';
 import { styles as gStyles } from '@components/style';
 import { PaperText as Text } from '@components/commonui/ScaledText';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 const domain = 'https://bilibili.com';
 

--- a/src/components/login/bilibili/Bilibili.tsx
+++ b/src/components/login/bilibili/Bilibili.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, StyleSheet, ScrollView } from 'react-native';
+import { View, StyleSheet, ScrollView, Linking } from 'react-native';
 import { Avatar, Button } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import QRCode from 'react-native-qrcode-svg';
@@ -96,6 +96,13 @@ const LoginPage = ({
       <Text>{t('Login.Disclaimer')}</Text>
       {qrcode !== '' && (
         <View style={styles.qrCodeContainerStyle}>
+          <Button
+            mode={'contained-tonal'}
+            onPress={() => Linking.openURL(qrcode)}
+            style={{ marginBottom: 10 }}
+          >
+            {t('Login.BilibiliLoginViaApp')}
+          </Button>
           <QRCode value={qrcode} size={300} />
         </View>
       )}

--- a/src/components/login/google/YTM.tsx
+++ b/src/components/login/google/YTM.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { BackHandler, SafeAreaView, StyleSheet, View } from 'react-native';
-import { Button, Avatar, ActivityIndicator } from 'react-native-paper';
+import { Button, Avatar } from 'react-native-paper';
 import { WebView } from 'react-native-webview';
 import { useFocusEffect } from '@react-navigation/native';
 import CookieManager from '@preeternal/react-native-cookie-manager';
@@ -15,6 +15,7 @@ import { initMuse } from '@utils/muse';
 import logger from '@utils/Logger';
 import { styles as stylesG } from '@components/style';
 import { PaperText as Text } from '@components/commonui/ScaledText';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 const jsCode = 'window.ReactNativeWebView.postMessage(document.cookie)';
 

--- a/src/components/miniplayer/MiniControls.tsx
+++ b/src/components/miniplayer/MiniControls.tsx
@@ -1,5 +1,10 @@
-import { ActivityIndicator, IconButton } from 'react-native-paper';
-import { Dimensions, TouchableWithoutFeedback, View } from 'react-native';
+import { IconButton } from 'react-native-paper';
+import {
+  Dimensions,
+  StyleSheet,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useDerivedValue,
@@ -14,12 +19,9 @@ import { MinPlayerHeight } from './Constants';
 import { useNoxSetting } from '@stores/useApp';
 import { PaperText as Text } from '@components/commonui/ScaledText';
 import { TPPlay } from '@stores/RNObserverStore';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 const IconSize = 30;
-const iconContainerStyle = {
-  width: IconSize + 28,
-  height: IconSize + 28,
-};
 const DoublePlayerHeight = MinPlayerHeight * 1.2;
 
 const TrackInfo = () => {
@@ -104,7 +106,9 @@ const PlayPauseButton = () => {
   const { showPause, showBuffering } = usePlaybackState();
 
   if (showBuffering) {
-    return <ActivityIndicator size={IconSize - 8} style={iconContainerStyle} />;
+    return (
+      <ActivityIndicator size={IconSize - 8} style={mStyles.iconContainer} />
+    );
   }
   return (
     <IconButton
@@ -115,3 +119,10 @@ const PlayPauseButton = () => {
     />
   );
 };
+
+const mStyles = StyleSheet.create({
+  iconContainer: {
+    width: IconSize + 28,
+    height: IconSize + 28,
+  },
+});

--- a/src/components/player/Lyric.tsx
+++ b/src/components/player/Lyric.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { Lrc as Lyric, KaraokeMode } from 'react-native-lyric';
 import { Track, useProgress } from 'react-native-track-player';
-import { IconButton, ActivityIndicator } from 'react-native-paper';
+import { IconButton } from 'react-native-paper';
 import { TrueSheet } from '@lodev09/react-native-true-sheet';
 import { LinearGradient } from 'expo-linear-gradient';
 import MaskedView from '@react-native-masked-view/masked-view';
@@ -22,6 +22,7 @@ import LyricBottomSheet from './LyricBottomSheet';
 import { NoxSheetRoutes } from '@enums/Routes';
 import { useIsLandscape } from '@hooks/useOrientation';
 import { TPSeek } from '@stores/RNObserverStore';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 interface LyricViewProps {
   track: Track;
@@ -128,8 +129,8 @@ export const LyricView = ({
       />
 
       {loading ? (
-        <Pressable onPress={onPress}>
-          <ActivityIndicator size={70} style={styles.lrcView} />
+        <Pressable onPress={onPress} style={[styles.lrcView, styles.center]}>
+          <ActivityIndicator size={70} />
         </Pressable>
       ) : (
         <FadingMaskedView fade={fadeEffect}>
@@ -223,6 +224,7 @@ export const LyricView = ({
 
 const styles = StyleSheet.create({
   lrcView: { height: 500, paddingHorizontal: 20 },
+  center: { alignItems: 'center', justifyContent: 'center' },
   container: {
     flex: 1,
   },

--- a/src/components/player/controls/PlayPauseButton.tsx
+++ b/src/components/player/controls/PlayPauseButton.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
-import { ActivityIndicator } from 'react-native-paper';
+
 import usePlaybackState from '@hooks/usePlaybackState';
 import { useNoxSetting } from '@stores/useApp';
 import LottieButtonAnimated from '@components/buttons/LottieButtonAnimated';
 import { fadePause } from '@utils/RNTPUtils';
 import { TPPlay } from '@stores/RNObserverStore';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 interface Props {
   iconSize?: number;

--- a/src/components/player/controls/ProgressBars/MD3NativeProgressBar.tsx
+++ b/src/components/player/controls/ProgressBars/MD3NativeProgressBar.tsx
@@ -38,15 +38,18 @@ export default function SimpleProgressBar({
     });
   }, [immediateShowPause]);
 
-  const onDragStateChange = (v: boolean) => {
-    'worklet';
-    scheduleOnRN(v ? enterSliding : exitSliding);
-    waveThickness.value = withTiming(v ? 20 : 6, { duration: 200 });
-    const actualWaveHeight = immediateShowPause ? 0 : 8;
-    waveHeight.value = withTiming(v ? 0 : actualWaveHeight, {
-      duration: 200,
-    });
-  };
+  const onDragStateChange = useMemo(
+    () => (v: boolean) => {
+      'worklet';
+      scheduleOnRN(v ? enterSliding : exitSliding);
+      waveThickness.value = withTiming(v ? 20 : 6, { duration: 200 });
+      const actualWaveHeight = immediateShowPause ? 0 : 8;
+      waveHeight.value = withTiming(v ? 0 : actualWaveHeight, {
+        duration: 200,
+      });
+    },
+    [enterSliding, exitSliding],
+  );
   const onValueChangeFinished = useMemo(
     () => (v: number) => {
       'worklet';

--- a/src/components/player/controls/ProgressBars/ProgressContainer.tsx
+++ b/src/components/player/controls/ProgressBars/ProgressContainer.tsx
@@ -33,7 +33,7 @@ const NativeProgress = (p: ProgressBarContainerProps) => (
 
 export default function ProgressContainer(p: ProgressBarContainerProps) {
   const playerSetting = useNoxSetting(state => state.playerSetting);
-  if (playerSetting.md3slider && isAndroid) {
+  if (playerSetting.md3slider && playerSetting.nativeBottomTab && isAndroid) {
     return <MD3NativeProgressBar {...p} />;
   }
   return (

--- a/src/components/setting/sync/GenericSyncButton.tsx
+++ b/src/components/setting/sync/GenericSyncButton.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { ActivityIndicator, IconButton } from 'react-native-paper';
+import { IconButton } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 
 import { logger } from '@utils/Logger';
 import { exportPlayerContent } from '@utils/ChromeStorageAPI';
 import useSnack from '@stores/useSnack';
 import keepAwake from '@utils/keepAwake';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 const ImportSyncFavButton = ({
   restoreFromUint8Array,

--- a/src/components/setting/sync/PersonalSyncButton.tsx
+++ b/src/components/setting/sync/PersonalSyncButton.tsx
@@ -1,7 +1,7 @@
 // TODO: migrate to GenericSyncButton
 import React, { useState } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { ActivityIndicator, IconButton, TextInput } from 'react-native-paper';
+import { IconButton, TextInput } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 
 import { PaperText as Text } from '@components/commonui/ScaledText';
@@ -10,6 +10,7 @@ import { useNoxSetting } from '@stores/useApp';
 import { logger } from '@utils/Logger';
 import { exportPlayerContent } from '@utils/ChromeStorageAPI';
 import useSnack from '@stores/useSnack';
+import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 interface Props {
   cloudAddress: string;

--- a/src/components/testing/ActivityIndicator.tsx
+++ b/src/components/testing/ActivityIndicator.tsx
@@ -3,7 +3,7 @@ import { Text, View } from 'react-native';
 
 import APMActivityIndicator from '@components/commonui/ActivityIndicator';
 
-export default () => {
+export default function Test() {
   return (
     <View style={{ top: 100, alignItems: 'center' }}>
       <View style={{ flexDirection: 'row' }}>
@@ -18,4 +18,4 @@ export default () => {
       </View>
     </View>
   );
-};
+}

--- a/src/components/testing/ActivityIndicator.tsx
+++ b/src/components/testing/ActivityIndicator.tsx
@@ -1,0 +1,21 @@
+import { ActivityIndicator } from 'react-native-paper';
+import { Text, View } from 'react-native';
+
+import APMActivityIndicator from '@components/commonui/ActivityIndicator';
+
+export default () => {
+  return (
+    <View style={{ top: 100, alignItems: 'center' }}>
+      <View style={{ flexDirection: 'row' }}>
+        <Text>1234</Text>
+        <ActivityIndicator size={50} />
+        <Text>1234</Text>
+      </View>
+      <View style={{ flexDirection: 'row' }}>
+        <Text>1234</Text>
+        <APMActivityIndicator size={50} />
+        <Text>1234</Text>
+      </View>
+    </View>
+  );
+};

--- a/src/hooks/useLyric.ts
+++ b/src/hooks/useLyric.ts
@@ -61,7 +61,7 @@ export default function useLyric(currentSong?: NoxMedia.Song) {
       updateLyricMapping({
         resolvedLrc,
         song,
-        currentTimeOffset,
+        currentTimeOffset: resolvedLyric?.lyricOffset ?? 0,
         lrc: lyric,
       });
     }

--- a/src/localization/en/translation.json
+++ b/src/localization/en/translation.json
@@ -446,7 +446,8 @@
   "SleepTimer": { "Title": "Sleep Timer" },
   "Login": {
     "BilibiliNotLoggedIn": "User not logged in\n",
-    "BilibiliLoginButton": "QR log in",
+    "BilibiliLoginButton": "QR Code login",
+    "BilibiliLoginViaApp": "Open link to log in via the Bilibili app",
     "BilibiliCookieInputButton": "Manually input cookies",
     "BilibiliCookieInputDialogTitle": "Add Bili Cookies",
     "BilibiliLoginQRGeneration": "Generating QR code...",

--- a/src/localization/zhcn/translation.json
+++ b/src/localization/zhcn/translation.json
@@ -449,6 +449,7 @@
   "Login": {
     "BilibiliNotLoggedIn": "用户未登录",
     "BilibiliLoginButton": "扫码登录",
+    "BilibiliLoginViaApp": "跳转b站APP登录",
     "BilibiliCookieInputButton": "手动填入cookie",
     "BilibiliCookieInputDialogTitle": "填入b站cookie",
     "BilibiliLoginQRGeneration": "正在生成二维码...",

--- a/src/types/component.d.ts
+++ b/src/types/component.d.ts
@@ -9,11 +9,16 @@ import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Track } from 'react-native-track-player';
 import { SharedValue } from 'react-native-reanimated';
+import { Props } from 'react-native-paper/src/components/ActivityIndicator';
 
 import { IntentData } from '@enums/Intent';
 
 declare global {
   namespace NoxComponent {
+    interface ActivityIndicatorProps extends Props {
+      wavy?: boolean;
+      trackColor?: string;
+    }
     interface ScrollableProps {
       onScroll?: (e: NativeSyntheticEvent<NativeScrollEvent>) => void;
       onMomentumScrollEnd?: (

--- a/src/types/component.d.ts
+++ b/src/types/component.d.ts
@@ -9,13 +9,13 @@ import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Track } from 'react-native-track-player';
 import { SharedValue } from 'react-native-reanimated';
-import { Props } from 'react-native-paper/src/components/ActivityIndicator';
+import { ActivityIndicatorProps as _ActivityIndicatorProps } from 'react-native-paper/';
 
 import { IntentData } from '@enums/Intent';
 
 declare global {
   namespace NoxComponent {
-    interface ActivityIndicatorProps extends Props {
+    interface ActivityIndicatorProps extends _ActivityIndicatorProps {
       wavy?: boolean;
       trackColor?: string;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6380,6 +6380,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/color-convert@npm:2":
+  version: 2.0.4
+  resolution: "@types/color-convert@npm:2.0.4"
+  dependencies:
+    "@types/color-name": "npm:^1.1.0"
+  checksum: 10c0/fdd2cea0ccf593055c8d952760286a4c114ed72a9940798d13f159823bf71d40a6b124009865e2e066f062d6d5611b677ddb61fd0ed05f6494170454cc6457c2
+  languageName: node
+  linkType: hard
+
+"@types/color-name@npm:^1.1.0":
+  version: 1.1.5
+  resolution: "@types/color-name@npm:1.1.5"
+  checksum: 10c0/ce566d98ab1c2622a2e9d9d1d5cbde403e731a4fc084e8b0f56e89901cd3c46981feafb797d4505918d5eb5a7fd897fce2332d489f450ddf1c58bc4986bd9d76
+  languageName: node
+  linkType: hard
+
+"@types/color@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@types/color@npm:4.2.1"
+  dependencies:
+    "@types/color-convert": "npm:2"
+  checksum: 10c0/fdf1558e91fd31e9d95bf60be08524b62815ab339aab4b1318672461044541eb7927e41427792dcc1da8d63680e3c572402414a5a8e1d3909ad3d65cb0b64c39
+  languageName: node
+  linkType: hard
+
 "@types/crypto-js@npm:^4.2.2":
   version: 4.2.2
   resolution: "@types/crypto-js@npm:4.2.2"
@@ -8602,6 +8627,7 @@ __metadata:
     "@shopify/flash-list": "npm:2.3.1"
     "@shopify/react-native-skia": "npm:2.6.4"
     "@tsconfig/react-native": "npm:^3.0.9"
+    "@types/color": "npm:^4.2.1"
     "@types/crypto-js": "npm:^4.2.2"
     "@types/d3": "npm:^7.4.3"
     "@types/he": "npm:^1.2.3"


### PR DESCRIPTION
migrates activityIndicator over.
fixes not setting currentTimeOffset right during lrc refetching 
adds a btn to open the qrcode link than scanning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct login option for Bilibili via app link

* **Improvements**
  * Consolidated loading indicators to a shared ActivityIndicator with Android MD3 support; updated many screens to use it
  * Lyric selection now persists resolved time offset
  * Minor progress bar behavior refinements on native/MD3 paths

* **Localization**
  * Updated Bilibili login text to “QR Code login”
  * Added Chinese label for app login

* **Chores**
  * Added TypeScript typings and an ActivityIndicator demo component
<!-- end of auto-generated comment: release notes by coderabbit.ai -->