### PR TITLE
fix: trackinfo style

### DIFF
--- a/src/components/miniplayer/MiniControls.tsx
+++ b/src/components/miniplayer/MiniControls.tsx
@@ -29,7 +29,7 @@ const TrackInfo = () => {
   const playerStyle = useNoxSetting(state => state.playerStyle);
 
   return (
-    <View style={[styles.centeredFlex, { paddingLeft: MinPlayerHeight }]}>
+    <View style={[styles.centeredFlex, mStyles.infoContainer]}>
       <Text
         testID={'miniplayer-track-title'}
         numberOfLines={2}
@@ -125,4 +125,5 @@ const mStyles = StyleSheet.create({
     width: IconSize + 28,
     height: IconSize + 28,
   },
+  infoContainer: { paddingLeft: MinPlayerHeight, height: MinPlayerHeight },
 });

--- a/src/components/player/TrackInfo/TrackInfoTemplate.tsx
+++ b/src/components/player/TrackInfo/TrackInfoTemplate.tsx
@@ -159,14 +159,17 @@ export const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '600',
     color: 'grey',
-    marginTop: 10,
     paddingHorizontal: 5,
     justifyContent: 'center',
     alignItems: 'center',
+    textAlignVertical: 'center',
+    height: 30,
   },
   artistText: {
     fontSize: 16,
     fontWeight: '200',
+    height: 24,
+    textAlignVertical: 'center',
   },
   infoContainer: {
     flexDirection: 'row',


### PR DESCRIPTION
font (chinese vs roman char) and text linecount will affect its elements height. if not using fixed heights this will cause visual artifacts of them sightly shifting around when its content change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual alignment and spacing of track information in the miniplayer.
  * Enhanced text layout and vertical alignment for track titles and artist names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->