### PR TITLE
fix: autocomplete focus

### DIFF
--- a/src/components/commonui/AutoComplete.tsx
+++ b/src/components/commonui/AutoComplete.tsx
@@ -12,8 +12,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useNoxSetting } from '@stores/useApp';
 import { styles as stylesGlobal } from '../style';
-import { set } from 'lodash';
-
 interface Props {
   placeholder: string;
   value: string;

--- a/src/components/commonui/AutoComplete.tsx
+++ b/src/components/commonui/AutoComplete.tsx
@@ -1,12 +1,18 @@
-import { View, GestureResponderEvent, StyleSheet } from 'react-native';
+import {
+  View,
+  GestureResponderEvent,
+  StyleSheet,
+  BackHandler,
+} from 'react-native';
 import { Menu, Searchbar } from 'react-native-paper';
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { useDebounce } from 'use-debounce';
 import { v4 as uuidv4 } from 'uuid';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useNoxSetting } from '@stores/useApp';
 import { styles as stylesGlobal } from '../style';
+import { set } from 'lodash';
 
 interface Props {
   placeholder: string;
@@ -43,6 +49,7 @@ export default function AutoComplete({
   });
 
   const onFocus = () => {
+    console.log('auto focused???');
     pressed.current = false;
     setShowAutoComplete(true);
   };
@@ -66,6 +73,25 @@ export default function AutoComplete({
     });
     setShowAutoComplete(true);
   }, [debouncedValue]);
+
+  useEffect(
+    useCallback(() => {
+      const onBackPress = () => {
+        if (showAutoComplete) {
+          setShowAutoComplete(false);
+          return true;
+        }
+        return false;
+      };
+
+      const subscription = BackHandler.addEventListener(
+        'hardwareBackPress',
+        onBackPress,
+      );
+
+      return () => subscription.remove();
+    }, [showAutoComplete]),
+  );
 
   return (
     <View style={styles.container}>

--- a/src/components/commonui/AutoComplete.tsx
+++ b/src/components/commonui/AutoComplete.tsx
@@ -47,7 +47,6 @@ export default function AutoComplete({
   });
 
   const onFocus = () => {
-    console.log('auto focused???');
     pressed.current = false;
     setShowAutoComplete(true);
   };
@@ -72,24 +71,22 @@ export default function AutoComplete({
     setShowAutoComplete(true);
   }, [debouncedValue]);
 
-  useEffect(
-    useCallback(() => {
-      const onBackPress = () => {
-        if (showAutoComplete) {
-          setShowAutoComplete(false);
-          return true;
-        }
-        return false;
-      };
+  useEffect(() => {
+    const onBackPress = () => {
+      if (showAutoComplete) {
+        setShowAutoComplete(false);
+        return true;
+      }
+      return false;
+    };
 
-      const subscription = BackHandler.addEventListener(
-        'hardwareBackPress',
-        onBackPress,
-      );
+    const subscription = BackHandler.addEventListener(
+      'hardwareBackPress',
+      onBackPress,
+    );
 
-      return () => subscription.remove();
-    }, [showAutoComplete]),
-  );
+    return () => subscription.remove();
+  }, [showAutoComplete]);
 
   return (
     <View style={styles.container}>

--- a/src/components/playlist/BiliSearch/BiliSearchbar.tsx
+++ b/src/components/playlist/BiliSearch/BiliSearchbar.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { ProgressBar } from 'react-native-paper';
+import { ProgressBar, TextInput } from 'react-native-paper';
 import {
   View,
   StyleSheet,
@@ -146,6 +146,7 @@ export default function BiliSearchBar({ onSearched = console.log }: Props) {
 
   return (
     <View style={styles.container}>
+      <TextInput style={styles.hidden} />
       <View style={styles.searchContainer}>
         <AutoComplete
           testID="BiliSearchBar"
@@ -192,4 +193,5 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   progressBar: { backgroundColor: 'rgba(0, 0, 0, 0)' },
+  hidden: { width: 0, position: 'absolute' },
 });


### PR DESCRIPTION
when a textinput was focused and dismissed, the autocomplete in the parent view's focus will be incorrectly refocused and trigger onfocus again. 

the interim fix is to add an invisible textinput to swallow the onfocus event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hardware back button support to close the autocomplete dropdown on mobile.

* **Improvements**
  * Updated the autocomplete dismissal behavior when the dropdown is open.
  * Adjusted the playlist search bar text input behavior by adding a hidden input and corresponding styling for smoother compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->