### PR TITLE
fix: miniplayer drag after entering lrc

### DIFF
--- a/src/components/miniplayer/Lrc.tsx
+++ b/src/components/miniplayer/Lrc.tsx
@@ -27,12 +27,15 @@ export default function MiniplayerLrc({
   const dimension = Dimensions.get('window');
   const playerSetting = useNoxSetting(state => state.playerSetting);
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    opacity: opacity.value,
-  }));
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      opacity: opacity.value,
+    };
+  });
 
   const lrcStyle: ViewStyle = {
     zIndex: visible ? 1 : -1,
+    opacity: 0,
     position: 'absolute',
     bottom: dimension.height - dimension.width - 200 + insets.bottom,
     width: '100%',
@@ -41,7 +44,6 @@ export default function MiniplayerLrc({
   useFocusEffect(
     useCallback(() => {
       if (playerSetting.screenAlwaysWake && visible) {
-        console.log(`screen mount?, ${visible}`);
         activateKeepAwakeAsync();
         return deactivateKeepAwake;
       }

--- a/src/components/miniplayer/View.tsx
+++ b/src/components/miniplayer/View.tsx
@@ -102,9 +102,8 @@ export default function MiniplayerView() {
 
   const onArtworkPress = () => {
     if (artworkOpacity.value === 1) {
-      artworkOpacity.value = withTiming(0, { duration: 100 }, () => {
-        scheduleOnRN(setLrcVisible, true);
-      });
+      artworkOpacity.value = withTiming(0, { duration: 100 });
+      setLrcVisible(true);
       return;
     }
     if (artworkOpacity.value === 0) {


### PR DESCRIPTION
UI bug introduced after RN 0.86.0. so much for "easiest upgrade" sure thing fb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mini player lyric view behavior so it can appear immediately when artwork is tapped, instead of waiting for the fade-out animation to finish.
  * Fixed lyric styling so opacity is applied consistently during animation transitions.
  * Removed an unnecessary debug log from the mini player screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->