### PR TITLE
Fix: background video gets stuck

### DIFF
--- a/src/components/background/MainBackground.tsx
+++ b/src/components/background/MainBackground.tsx
@@ -66,6 +66,11 @@ const MainBackground = () => {
       logger.error(
         `[MainBackground] Video error: ${status.error.message} while playing ${bkgrdImg?.identifier}`,
       );
+      if (
+        status.error.message.includes('Player stuck playing without ending')
+      ) {
+        prepareBackground();
+      }
     }
   });
 
@@ -76,6 +81,11 @@ const MainBackground = () => {
       }
       try {
         player.play();
+        setTimeout(() => {
+          if (!player.playing) {
+            prepareBackground();
+          }
+        }, 100);
         primeVideoPosition();
       } catch {
         prepareBackground();

--- a/src/components/background/MainBackground.tsx
+++ b/src/components/background/MainBackground.tsx
@@ -80,7 +80,9 @@ const MainBackground = () => {
         return;
       }
       try {
-        player.play();
+        setTimeout(() => {
+          player.play();
+        }, 1);
         setTimeout(() => {
           if (!player.playing) {
             prepareBackground();


### PR DESCRIPTION
Might be related to an expo video version?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background video recovery when playback becomes stuck.
  * Enhanced background playback resumption when returning to the app.
  * Automatically reloads the background if playback does not resume successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->