### PR TITLE
fix: lrc window loading

### DIFF
--- a/src/components/miniplayer/Lrc.tsx
+++ b/src/components/miniplayer/Lrc.tsx
@@ -8,7 +8,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTrackStore } from '@hooks/useActiveTrack';
 import { LyricView } from '../player/Lyric';
 import { useNoxSetting } from '@stores/useApp';
-import logger from '@utils/Logger';
 
 interface Props extends NoxComponent.OpacityProps {
   visible: boolean;
@@ -51,13 +50,6 @@ export default function MiniplayerLrc({
     }, [visible, playerSetting.screenAlwaysWake]),
   );
 
-  logger.debug(
-    `[lrc] dimension: ${dimension.height} - ${dimension.width} - ${insets.bottom}`,
-  );
-
-  if (!visible || !track) {
-    return <></>;
-  }
   return (
     <Animated.View style={[animatedStyle, lrcStyle, style]}>
       <LyricView
@@ -66,6 +58,7 @@ export default function MiniplayerLrc({
         onPress={onPress}
         height={dimension.width + 100}
         style={{}}
+        visible={visible}
       />
     </Animated.View>
   );

--- a/src/components/player/Lyric.tsx
+++ b/src/components/player/Lyric.tsx
@@ -25,7 +25,7 @@ import { TPSeek } from '@stores/RNObserverStore';
 import ActivityIndicator from '@components/commonui/ActivityIndicator';
 
 interface LyricViewProps {
-  track: Track;
+  track?: Track;
   artist: string;
   height?: number;
   showUI?: boolean;
@@ -91,7 +91,7 @@ export const LyricView = ({
   );
   const [offsetModalVisible, setOffsetModalVisible] = useState(false);
   const playerStyle = useNoxSetting(state => state.playerStyle);
-  const usedLyric = useLyric(track.song, artist);
+  const usedLyric = useLyric(track?.song, artist);
   const {
     loading,
     hasLrcFromLocal,


### PR DESCRIPTION
now `<LryicWindow>/useLyric` is always loaded that lrcfetch properly runs in the background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lyric display behavior in the mini-player when no track is selected.
  * Lyric views now correctly respond to the mini-player’s visibility state.
  * Removed unnecessary debug logging from the mini-player lyrics view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->