### PR TITLE
feat: refactor useLyric to a hook

### DIFF
--- a/src/components/miniplayer/Lrc.tsx
+++ b/src/components/miniplayer/Lrc.tsx
@@ -8,6 +8,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTrackStore } from '@hooks/useActiveTrack';
 import { LyricView } from '../player/Lyric';
 import { useNoxSetting } from '@stores/useApp';
+import useLyric from '@hooks/useRNTPLyric';
 
 interface Props extends NoxComponent.OpacityProps {
   visible: boolean;
@@ -25,6 +26,7 @@ export default function MiniplayerLrc({
   const track = useTrackStore(s => s.track);
   const dimension = Dimensions.get('window');
   const playerSetting = useNoxSetting(state => state.playerSetting);
+  const usedLyric = useLyric({ track, artist: track?.artist ?? '' });
 
   const animatedStyle = useAnimatedStyle(() => {
     return {
@@ -50,9 +52,14 @@ export default function MiniplayerLrc({
     }, [visible, playerSetting.screenAlwaysWake]),
   );
 
+  if (!visible || !track) {
+    return <></>;
+  }
+
   return (
     <Animated.View style={[animatedStyle, lrcStyle, style]}>
       <LyricView
+        usedLyric={usedLyric}
         track={track}
         artist="n/a"
         onPress={onPress}

--- a/src/components/player/Lyric.tsx
+++ b/src/components/player/Lyric.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Modal,
   View,
@@ -34,6 +34,7 @@ interface LyricViewProps {
   visible?: boolean;
   style?: ViewStyle;
   fadeEffect?: boolean;
+  usedLyric: ReturnType<typeof useLyric>;
 }
 
 interface FadingMaskedViewProps extends React.PropsWithChildren {
@@ -82,6 +83,7 @@ export const LyricView = ({
   visible = true,
   style = styles.container,
   fadeEffect = true,
+  usedLyric,
 }: LyricViewProps) => {
   const isLandscape = useIsLandscape();
   const playerSetting = useNoxSetting(state => state.playerSetting);
@@ -91,33 +93,10 @@ export const LyricView = ({
   );
   const [offsetModalVisible, setOffsetModalVisible] = useState(false);
   const playerStyle = useNoxSetting(state => state.playerStyle);
-  const usedLyric = useLyric(track?.song, artist);
-  const {
-    loading,
-    hasLrcFromLocal,
-    searchAndSetCurrentLyric,
-    addSubtractOffset,
-    initTrackLrcLoad,
-    lrc,
-    lrcOptions,
-    currentTimeOffset,
-  } = usedLyric;
+  const { loading, addSubtractOffset, lrc, currentTimeOffset } = usedLyric;
   const spotifyLyricStyle = playerSetting.spotifyLyricStyle
     ? SpotifyLyricStyle
     : {};
-
-  useEffect(() => {
-    if (track === undefined || track.title === '') return;
-    initTrackLrcLoad();
-  }, [track]);
-
-  useEffect(() => {
-    const init = async () => {
-      if (await hasLrcFromLocal(track?.song)) return;
-      searchAndSetCurrentLyric({});
-    };
-    init();
-  }, [lrcOptions]);
 
   if (!visible) return null;
 

--- a/src/components/player/PIPLyric.tsx
+++ b/src/components/player/PIPLyric.tsx
@@ -5,6 +5,7 @@ import TrackPlayer, { Track } from 'react-native-track-player';
 import { useNoxSetting } from '@stores/useApp';
 import { LyricView } from './Lyric';
 import usePlayerControls from '@components/player/controls/usePlayerControls';
+import useLyric from '@hooks/useRNTPLyric';
 
 const PIPLyricView = () => {
   const [currentTrack, setCurrentTrack] = useState<Track | undefined>(
@@ -15,12 +16,18 @@ const PIPLyricView = () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const _ = usePlayerControls();
 
+  const usedLyric = useLyric({
+    track: currentTrack,
+    artist: currentTrack?.artist ?? '',
+  });
+
   React.useEffect(() => {
     TrackPlayer.getActiveTrack().then(setCurrentTrack);
   }, [currentPlayingId]);
 
   return currentTrack ? (
     <LyricView
+      usedLyric={usedLyric}
       track={currentTrack}
       artist={'n/a'}
       // HACK: for problems see https://github.com/facebook/react-native/issues/34324

--- a/src/components/player/TrackInfo/AlbumArt.tsx
+++ b/src/components/player/TrackInfo/AlbumArt.tsx
@@ -14,6 +14,7 @@ import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import { useNoxSetting } from '@stores/useApp';
 import { LyricView } from '../Lyric';
 import { songResolveArtwork } from '@utils/mediafetch/resolveURL';
+import useLyric from '@hooks/useRNTPLyric';
 
 interface Props {
   track?: Track;
@@ -39,6 +40,7 @@ const AlbumArt: React.FC<Props> = ({
     width: windowWidth ?? '100%',
     height: windowHeight ?? '100%',
   };
+  const usedLyric = useLyric({ track, artist: track?.artist ?? '' });
 
   const onImagePress = () => {
     console.log('TrackInfo: Image Clicked - ');
@@ -128,6 +130,7 @@ const AlbumArt: React.FC<Props> = ({
       >
         {track && (
           <LyricView
+            usedLyric={usedLyric}
             track={track}
             artist="n/a"
             onPress={onLyricPress}

--- a/src/hooks/useLyricRN.ts
+++ b/src/hooks/useLyricRN.ts
@@ -1,3 +1,5 @@
+import TrackPlayer from 'react-native-track-player';
+
 import { logger } from '@utils/Logger';
 import { readTxtFile, writeTxtFile } from '@utils/fs';
 import useLyric from './useLyric';
@@ -32,7 +34,12 @@ export default function useLyricRN(currentSong?: NoxMedia.Song, artist = '') {
         lyric: lrcpath,
         source: resolvedLrc.source,
       };
-      usedLyric.setLyricMapping(lyricDeatail);
+      TrackPlayer.getActiveTrack().then(track => {
+        if (track?.song?.id !== song.id) {
+          return;
+        }
+        usedLyric.setLyricMapping(lyricDeatail);
+      });
     }
   };
 

--- a/src/hooks/useRNTPLyric.ts
+++ b/src/hooks/useRNTPLyric.ts
@@ -1,0 +1,36 @@
+// this is a useLyric hook that manages the various useEffects previously in Lryic.tsx
+
+import { Track } from 'react-native-track-player';
+import { useEffect } from 'react';
+
+import useLyric from '@hooks/useLyricRN';
+
+interface Props {
+  track?: Track;
+  artist: string;
+}
+
+export default ({ track, artist }: Props) => {
+  const usedLyric = useLyric(track?.song, artist);
+  const {
+    hasLrcFromLocal,
+    searchAndSetCurrentLyric,
+    initTrackLrcLoad,
+    lrcOptions,
+  } = usedLyric;
+
+  useEffect(() => {
+    if (track === undefined || track.title === '') return;
+    initTrackLrcLoad();
+  }, [track]);
+
+  useEffect(() => {
+    const init = async () => {
+      if (await hasLrcFromLocal(track?.song)) return;
+      searchAndSetCurrentLyric({});
+    };
+    init();
+  }, [lrcOptions]);
+
+  return usedLyric;
+};

--- a/src/utils/lrcfetch/lrclib.ts
+++ b/src/utils/lrcfetch/lrclib.ts
@@ -4,7 +4,7 @@ import bfetch from '@utils/BiliFetch';
 import { LrcSource } from '@enums/LyricFetch';
 import { logger } from '../Logger';
 
-const SearchSongAPI = 'https://lrclib.net/api/search?track_name=${kw}';
+const SearchSongAPI = 'https://lrclib.net/api/search?q=${kw}';
 const getLrcAPI = 'https://lrclib.net/api/get/${kw}';
 
 const getLrcOptions = async (


### PR DESCRIPTION
the MD3 native progress bar flashes if the visible control is NOT in miniplayer/Lrc (would like to be in player/lrc). thus i need to extract the useLyric logic out and put into miniplayer/lrc to keep it in the background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lyrics now load and display consistently across the mini-player, picture-in-picture player, album artwork view, and main player.
  * Added support for automatically finding and loading locally available lyrics.
* **Bug Fixes**
  * Prevented lyrics from being applied to the wrong track when playback changes quickly.
  * Improved behavior when no track is active or the mini-player is hidden.
  * Improved lyric search compatibility for a wider range of tracks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->