### PR TITLE
fix: b23tv

### DIFF
--- a/src/utils/BiliSearch.ts
+++ b/src/utils/BiliSearch.ts
@@ -244,6 +244,10 @@ const reExtractions: ReExtraction<NoxNetwork.NoxRegexFetch>[] = [
     fetch: biliChannelFetch.regexFetch,
   },
   {
+    match: biliChannelFetch.regexSearchMatch5,
+    fetch: biliChannelFetch.regexFetch,
+  },
+  {
     match: biliChannelAudioFetch.regexSearchMatch,
     fetch: biliChannelAudioFetch.regexFetch,
   },

--- a/src/utils/mediafetch/b23tv.ts
+++ b/src/utils/mediafetch/b23tv.ts
@@ -3,9 +3,12 @@ import bFetch from '../BiliFetch';
 
 const resolveB23TV = async (url: string) => {
   logger.debug(`[b23.tv] fetching ${url}`);
-  const res = await bFetch(`https://b23.tv/${url}`, {
-    // method: 'HEAD',
-  });
+  const res = await fetch(`https://b23.tv/${url}`, { method: 'HEAD' });
+  return res.url;
+};
+
+export const resolveB23TVVideo = async (url: string) => {
+  const res = await bFetch(`https://b23.tv/${url}`);
   const body = await res.text();
   // match for content="https://www.bilibili.com/video/???
   const match = /content="(https?:\/\/www\.bilibili\.com\/video\/.+?)"/.exec(

--- a/src/utils/mediafetch/bilichannel.ts
+++ b/src/utils/mediafetch/bilichannel.ts
@@ -109,13 +109,15 @@ const regexFetch = async ({
 const resolveURL = () => undefined;
 
 export default {
-  regexSearchMatch: /space.bilibili\.com\/(\d+)(\/search)?\/video/,
+  regexSearchMatch: /space\.bilibili\.com\/(\d+)(\/search)?\/video/,
   // https://space.bilibili.com/1112031857/upload/video
-  regexSearchMatch2: /space.bilibili\.com\/(\d+)(\/upload)?\/video/,
+  regexSearchMatch2: /space\.bilibili\.com\/(\d+)(\/upload)?\/video/,
   // https://space.bilibili.com/2097484/search?keyword=f
-  regexSearchMatch3: /space.bilibili\.com\/(\d+)\/search/,
+  regexSearchMatch3: /space\.bilibili\.com\/(\d+)\/search/,
   // https://space.bilibili.com/2097484/search?keyword=f
   regexSearchMatch4: /bilibili\.com\/space\/(\d+)/,
+  // https://space.bilibili.com/2097484
+  regexSearchMatch5: /space\.bilibili\.com\/(\d+)$/,
   regexFetch,
   regexResolveURLMatch: /^null-/,
   resolveURL,


### PR DESCRIPTION
method:head works again (why? how?)

closes #1341 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of direct Bilibili channel URLs so they are resolved through the channel extractor.
  * Improved B23.tv URL resolution by following the final destination URL.
  * Improved B23.tv video fetching behavior for more reliable playback resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->