### PR TITLE
fix: normalize Chinese locale detection on Android/iOS

### DIFF
--- a/src/localization/i18n.ts
+++ b/src/localization/i18n.ts
@@ -22,7 +22,26 @@ function getLocale() {
 
   return currentLocale;
 }
-const deviceLanguage = getLocale();
+
+/**
+ * Normalize device locale to internal resource keys.
+ *
+ * Android ROMs and iOS may return Chinese locales in different formats,
+ * e.g. zh_CN, zh-CN, zh-Hans-CN, zh_CN_#Hans. Without normalization the
+ * exact-match lookup in `resources` fails and i18next falls back to English.
+ *
+ * @see resources for the list of supported internal language keys.
+ */
+export function normalizeLocale(locale?: string): string {
+  if (!locale) return 'en';
+  const normalized = locale.toLowerCase();
+  if (normalized.startsWith('zh')) {
+    return 'zh_CN_#Hans';
+  }
+  return 'en';
+}
+
+const deviceLanguage = normalizeLocale(getLocale());
 /**
   Platform.OS === 'ios'
     ? NativeModules.SettingsManager.settings.AppleLocale ||

--- a/src/stores/initializeStores.ts
+++ b/src/stores/initializeStores.ts
@@ -51,7 +51,12 @@ export const initializeStores = async ({
   ) {
     setCurrentPlayingList(dataSaverPlaylist(results.currentPlayingList));
   }
-  i18next.changeLanguage(results.language);
+  // Only override i18n language when the user has explicitly chosen one.
+  // For fresh installs (language undefined) keep the normalized system locale
+  // set during i18n module initialization.
+  if (results.language) {
+    i18next.changeLanguage(results.language);
+  }
   return results;
 };
 


### PR DESCRIPTION
## Problem

On Chinese-language devices (especially Android), the app consistently falls back to English UI even though a complete Simplified Chinese translation exists at `src/localization/zhcn/translation.json`.

## Root Cause

Two issues combine to cause this:

### 1. Locale mismatch in `i18n.ts`

The i18n resources use the exact key `zh_CN_#Hans`:

```ts
export const resources = {
  'zh_CN_#Hans': { translation: translationZHCN },
  en: { translation: translationEN },
};
```

However, `I18nManager.getConstants().localeIdentifier` on Android (and `AppleLocale` on iOS) can return Chinese locales in various formats: `zh_CN`, `zh-CN`, `zh-Hans-CN`, `zh_CN_#Hans`, etc. Since i18next does an exact key lookup and none of these (except the rare exact match) equals `zh_CN_#Hans`, it falls back to `fallbackLng: 'en'`.

### 2. `changeLanguage(undefined)` on fresh installs

The default setting `language` is `undefined` (see `src/objects/Storage.ts`). On startup, `initializeStores.ts` unconditionally calls:

```ts
i18next.changeLanguage(results.language); // results.language is undefined for new users
```

This can override the locale detected during i18n module initialization, even when it was correctly detected.

## Changes

### `src/localization/i18n.ts`
- Added `normalizeLocale(locale?: string): string` that maps any `zh*` locale to the internal key `zh_CN_#Hans`, and everything else to `en`.
- `deviceLanguage` now uses `normalizeLocale(getLocale())` instead of the raw device locale.
- The function is exported for potential reuse (e.g., future language selector improvements).

### `src/stores/initializeStores.ts`
- Only call `i18next.changeLanguage(results.language)` when `results.language` is truthy (user has explicitly chosen a language).
- For fresh installs, keep the normalized system locale set during i18n initialization.

## Verification

- `yarn types` (tsc --noEmit) passes with no errors.
- The change is backward-compatible: users who already selected a language in Settings will continue to have their preference restored on startup.
- Existing resource keys, `LanguageSettings.tsx`, and the shawarma voice pack are unchanged — this fix only affects the initial detection path.

## Impact

- Chinese-system users will see Chinese UI on first launch, without needing to find the language setting.
- No behavior change for English-system users or users who have explicitly set a language.
- Minimal diff (2 files, +26/-2 lines), low regression risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection for Chinese device locales across different formats.
  * Fresh installs now retain the device’s detected language instead of unintentionally changing it when no language preference is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->